### PR TITLE
クライアントアプリケーションの不要なログ出力を削除する

### DIFF
--- a/samples/web-csr/dressca-frontend/src/components/basket/BasketItem.vue
+++ b/samples/web-csr/dressca-frontend/src/components/basket/BasketItem.vue
@@ -34,7 +34,6 @@ const isUpdateDisabled = computed(
 );
 
 const update = () => {
-  console.log('update: ');
   emit('update', props.item.catalogItemId, quantity.value);
 };
 


### PR DESCRIPTION
samples/web-csr/dressca-frontend/src/components/basket/BasketItem.vue：37行目の不要なログ出力を削除