### PR TITLE
Javaのdependabotの有効化設定の変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,66 @@ updates:
       - "dependencies"
 
   - package-ecosystem: "gradle"
-    directory: "/"
+    directory: "/samples/web-csr/dressca-backend"
     schedule:
       interval: "daily"
     commit-message:
       prefix: "gradle-root"
+    labels:
+      - "ドキュメント改善"
+      - "gradle"
+      - "dependencies"
+
+  - package-ecosystem: "gradle"
+    directory: "/samples/web-csr/dressca-backend/application-core"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "gradle-application-core"
+    labels:
+      - "ドキュメント改善"
+      - "gradle"
+      - "dependencies"
+
+  - package-ecosystem: "gradle"
+    directory: "/samples/web-csr/dressca-backend/batch"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "gradle-batch"
+    labels:
+      - "ドキュメント改善"
+      - "gradle"
+      - "dependencies"
+
+  - package-ecosystem: "gradle"
+    directory: "/samples/web-csr/dressca-backend/infrastructure"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "gradle-infrastructure"
+    labels:
+      - "ドキュメント改善"
+      - "gradle"
+      - "dependencies"
+
+  - package-ecosystem: "gradle"
+    directory: "/samples/web-csr/dressca-backend/system-common"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "gradle-system-common"
+    labels:
+      - "ドキュメント改善"
+      - "gradle"
+      - "dependencies"
+
+  - package-ecosystem: "gradle"
+    directory: "/samples/web-csr/dressca-backend/web"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "gradle-web"
     labels:
       - "ドキュメント改善"
       - "gradle"


### PR DESCRIPTION
dependabot.ymlの修正
gradleの設定について、"directory"にbuild.gradleファイルが存在するディレクトリのパスを指定
build.gradleファイルはルートプロジェクトと各プロジェクトに存在するため、それぞれ設定を追加