### PR TITLE
index.mdのアプリケーション実行方法のテキストを変更

### DIFF
--- a/documents/contents/index.md
+++ b/documents/contents/index.md
@@ -99,7 +99,7 @@ AlesInfiny Maia で構築した Web アプリケーションのサンプルを�
     ./gradlew build
     ```
 
-1. VS Code のエクスプローラーの「SPRING BOOT DASHBOARD」から「web」という名前のアプリケーションを実行します。
+1. VS Code のアクティビティーバーにある「Spring Boot Dashboard」をクリックし、サイドバーの「APPS」タブにある「web」という名前のアプリケーションを実行します。
 
 1. 以下のアドレスで、サンプルアプリケーションの API にアクセスできます。
 


### PR DESCRIPTION
複数のWebサイトからVSCodeの画面構成について検索し、その名称に従って処理方法を記述しました。

参考URL
[https://www.webolve.com/software/screen-configuration-and-role-of-visual-studio-code/#link3-2](url)
[https://diveintocode.jp/blogs/Technology/depVscodeUserInterface](url)

VSCodeのアクティビティーバーにカーソルを合わせた際に大文字と小文字の組合せで記述されていることを確認したため、
「SPRING BOOT DASHBOARD」-> 「Spring Boot Dashboard」
という形に記述を変更しました。

ご確認よろしくお願いいたします。
