### PR TITLE
Azure AD B2C サンプルアプリケーションにOpen API 仕様書のソートを適用

### DIFF
--- a/samples/azure-ad-b2c-sample/auth-backend/api-docs/api-specification.json
+++ b/samples/azure-ad-b2c-sample/auth-backend/api-docs/api-specification.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.0.1",
   "info": {
-    "title": "Azure AD B2C ユーザー認証",
     "description": "Azure AD B2Cを利用したユーザー認証機能を提供するサンプルアプリケーションです。",
+    "title": "Azure AD B2C ユーザー認証",
     "version": "v1"
   },
   "servers": [
@@ -13,98 +13,98 @@
   ],
   "tags": [
     {
-      "name": "ServerTime",
-      "description": "認証不要でサーバーの現在時刻を取得する"
+      "description": "認証不要でサーバーの現在時刻を取得する",
+      "name": "ServerTime"
     },
     {
-      "name": "User",
-      "description": "認証済みユーザのユーザIDを取得するAPI"
+      "description": "認証済みユーザのユーザIDを取得するAPI",
+      "name": "User"
     }
   ],
   "paths": {
-    "/api/user": {
-      "get": {
-        "tags": [
-          "User"
-        ],
-        "summary": "ログインに成功したユーザIDを取得します.",
-        "description": "ログインに成功したユーザIDを取得します.",
-        "operationId": "getUser",
-        "responses": {
-          "401": {
-            "description": "未認証エラー."
-          },
-          "200": {
-            "description": "成功.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ]
-      }
-    },
     "/api/servertime": {
       "get": {
-        "tags": [
-          "ServerTime"
-        ],
-        "summary": "サーバーの現在時刻を取得します.",
         "description": "サーバーの現在時刻を取得します.",
         "operationId": "getServerTime",
         "responses": {
           "200": {
-            "description": "成功.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TimeResponse"
                 }
               }
-            }
+            },
+            "description": "成功."
           }
-        }
+        },
+        "summary": "サーバーの現在時刻を取得します.",
+        "tags": [
+          "ServerTime"
+        ]
+      }
+    },
+    "/api/user": {
+      "get": {
+        "description": "ログインに成功したユーザIDを取得します.",
+        "operationId": "getUser",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponse"
+                }
+              }
+            },
+            "description": "成功."
+          },
+          "401": {
+            "description": "未認証エラー."
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "summary": "ログインに成功したユーザIDを取得します.",
+        "tags": [
+          "User"
+        ]
       }
     }
   },
   "components": {
     "schemas": {
-      "UserResponse": {
-        "required": [
-          "userId"
-        ],
-        "type": "object",
-        "properties": {
-          "userId": {
-            "type": "string"
-          }
-        }
-      },
       "TimeResponse": {
-        "required": [
-          "serverTime"
-        ],
         "type": "object",
         "properties": {
           "serverTime": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "serverTime"
+        ]
+      },
+      "UserResponse": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "userId"
+        ]
       }
     },
     "securitySchemes": {
       "Bearer": {
-        "type": "http",
+        "bearerFormat": "JWT",
         "scheme": "bearer",
-        "bearerFormat": "JWT"
+        "type": "http"
       }
     }
   }

--- a/samples/azure-ad-b2c-sample/auth-backend/web/src/main/resources/application.properties
+++ b/samples/azure-ad-b2c-sample/auth-backend/web/src/main/resources/application.properties
@@ -12,9 +12,11 @@ spring.cloud.azure.active-directory.b2c.credential.client-id=client-id
 spring.cloud.azure.active-directory.b2c.profile.tenant-id=tenant-id
 spring.cloud.azure.active-directory.b2c.user-flows.sign-up-or-sign-in=B2C_1_user-flows
 
-
 # ログの詳細化
 logging.level.org.springframework.security=DEBUG
 
 # CROS設定
 cors.allowed.origins=http://localhost:5173
+
+# Open API 仕様書を自動生成する際keyをアルファベット順でソートする
+springdoc.writer-with-order-by-keys=true


### PR DESCRIPTION
springdoc.writer-with-order-by-keys=true
のプロパティをAzure AD B2Cサンプルアプリケーションに適用しました。
また、それに伴いOpenAPI仕様書を再生成し、ソートされていることを確認しました。