### PR TITLE
バックエンドアプリケーションのパイプラインをpull requestに限定

### DIFF
--- a/.github/workflows/back-sample-pull-request-ut.yml
+++ b/.github/workflows/back-sample-pull-request-ut.yml
@@ -3,11 +3,6 @@
 name: バックエンドサンプルAPに対するプルリクエスト時の単体テスト実行
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'samples/web-csr/dressca-backend/**'
-      - '.github/workflows/back-sample-pull-request-ut.yml'
   pull_request:
     branches: [main]
     paths:


### PR DESCRIPTION
バックエンドアプリケーションのパイプラインをpull requestに限定しました。
具体的には pushの記載を削除しました。