### PR TITLE
vitestの設定ファイルvitest.config.tsを追加する

### DIFF
--- a/samples/azure-ad-b2c-sample/auth-frontend/package.json
+++ b/samples/azure-ad-b2c-sample/auth-frontend/package.json
@@ -6,7 +6,7 @@
     "build": "run-p typecheck build-only --print-label",
     "build-only": "vite build",
     "preview": "vite preview --port 5050",
-    "test:unit": "vitest --environment jsdom",
+    "test:unit": "vitest",
     "typecheck": "vue-tsc --build --force",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
     "generate-client": "run-s openapi-client:clean openapi-client:generate --print-label",

--- a/samples/azure-ad-b2c-sample/auth-frontend/vitest.config.ts
+++ b/samples/azure-ad-b2c-sample/auth-frontend/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from 'node:url';
+import { mergeConfig, defineConfig, configDefaults } from 'vitest/config';
+import viteConfig from './vite.config';
+
+export default defineConfig((configEnv) =>
+  mergeConfig(
+    viteConfig(configEnv),
+    defineConfig({
+      test: {
+        environment: 'jsdom',
+        exclude: [...configDefaults.exclude, 'e2e/*'],
+        root: fileURLToPath(new URL('./', import.meta.url)),
+      },
+    }),
+  ),
+);

--- a/samples/web-csr/dressca-frontend/package.json
+++ b/samples/web-csr/dressca-frontend/package.json
@@ -7,7 +7,7 @@
     "build": "run-p typecheck build-only --print-label",
     "build-only": "vite build",
     "preview": "vite preview --port 5050",
-    "test:unit": "vitest --environment jsdom",
+    "test:unit": "vitest",
     "test:e2e": "start-server-and-test dev http://localhost:5173/ 'cypress open --e2e --browser chrome'",
     "test:e2e:ci": "start-server-and-test dev http://localhost:5173/ 'cypress run'",
     "typecheck": "vue-tsc --build --force",

--- a/samples/web-csr/dressca-frontend/vitest.config.ts
+++ b/samples/web-csr/dressca-frontend/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from 'node:url';
+import { mergeConfig, defineConfig, configDefaults } from 'vitest/config';
+import viteConfig from './vite.config';
+
+export default defineConfig((configEnv) =>
+  mergeConfig(
+    viteConfig(configEnv),
+    defineConfig({
+      test: {
+        environment: 'jsdom',
+        exclude: [...configDefaults.exclude, 'e2e/*'],
+        root: fileURLToPath(new URL('./', import.meta.url)),
+      },
+    }),
+  ),
+);


### PR DESCRIPTION
# 申し送り事項
- AzureADB2Cのほうはテストスイートがないため、npm run test:unitコマンドが実行できることのみを確認