### PR TITLE
バックエンドアプリケーションの推奨拡張機能に「Gradle for Java」を追加

### DIFF
--- a/samples/azure-ad-b2c-sample/auth-backend/.vscode/extensions.json
+++ b/samples/azure-ad-b2c-sample/auth-backend/.vscode/extensions.json
@@ -1,7 +1,8 @@
 {
   "recommendations": [
-    "vscjava.vscode-java-pack",
     "vmware.vscode-boot-dev-pack",
+    "vscjava.vscode-gradle",
+    "vscjava.vscode-java-pack",
     "vscjava.vscode-lombok",
     "redhat.java"
   ]

--- a/samples/web-csr/dressca-backend/.vscode/extensions.json
+++ b/samples/web-csr/dressca-backend/.vscode/extensions.json
@@ -1,7 +1,8 @@
 {
   "recommendations": [
-    "vscjava.vscode-java-pack",
     "vmware.vscode-boot-dev-pack",
+    "vscjava.vscode-gradle",
+    "vscjava.vscode-java-pack",
     "vscjava.vscode-lombok",
     "redhat.java"
   ]


### PR DESCRIPTION
推奨拡張機能にGradle for Java を追加しました。
一度アンインストール後、VSCodeを再起動したところ、Gradle for Java が推奨拡張機能として表示されることを確認しました。

![image](https://github.com/user-attachments/assets/f6053bed-8e43-4ad4-a0d1-82ac28de6c8d)
