### PR TITLE
Atomic Designのドキュメント内に記載されているフォルダー名を修正

### DIFF
--- a/documents/contents/app-architecture/client-side-rendering/frontend-application/index.md
+++ b/documents/contents/app-architecture/client-side-rendering/frontend-application/index.md
@@ -224,7 +224,7 @@ src/
 ``` text title="components フォルダー by Atomic Design" linenums="0"
 src/
 └─ components/
-   ├─ atoms&molecules/
+   ├─ atoms-and-molecules/
    │  ├─ Button.vue
    │  ├─ Input.vue
    │  └─ Form.vue


### PR DESCRIPTION
「atoms&molecules」というフォルダー名を以下のように変更しました。

「atoms-and-molecules」

「api-client」のようにほかのフォルダー名では、ハイフンで単語を区切っていたためそれに従った変更としています。