### PR TITLE
Spring Initializrを利用したプロジェクト作成手順ドキュメントを更新する

### DIFF
--- a/documents/contents/app-architecture/client-side-rendering/csr-architecture-overview.md
+++ b/documents/contents/app-architecture/client-side-rendering/csr-architecture-overview.md
@@ -211,7 +211,7 @@ AlesInfiny Maia では Java のプロジェクト構成として、複数のサ�
 ![フォルダ構成図](../../images/app-architecture/client-side-rendering/csr-project-structure-light.png#only-light){ loading=lazy }
 ![フォルダ構成図](../../images/app-architecture/client-side-rendering/csr-project-structure-dark.png#only-dark){ loading=lazy }
 
-プロジェクト構造全体は、 Spring Initializr で生成した Gradle プロジェクトの構造と変わりはありません。
+プロジェクト構造全体は、 Spring Initializr で生成した Gradle Groovy DSL プロジェクトの構造と変わりはありません。
 パッケージの構成としては、システムで 1 つのフォルダー ( aa.bb.cc ) をベースに、各層に対応するパッケージ ( application-core など ) を作成します。
 アプリケーションコア層については、ドメインの単位でパッケージを作成し、それ以外の層については、構成するコンポーネント単位でパッケージを作成することを想定しています。
 以降の階層については、管理や機能面を考慮し、必要に応じてサブパッケージを作成してください。

--- a/documents/contents/guidebooks/how-to-develop/java/application-structure.md
+++ b/documents/contents/guidebooks/how-to-develop/java/application-structure.md
@@ -5,6 +5,6 @@ description: バックエンドで動作する Java アプリケーションの 
 
 # アプリケーションの全体構造 {#top}
 
-AlesInfiny Maia OSS Edition において、バックエンドで動作する Java アプリケーションは複数の Gradle プロジェクトを組み合わせたマルチプロジェクトとして構成します。
+AlesInfiny Maia OSS Edition において、バックエンドで動作する Java アプリケーションは複数の Gradle Groovy DSL プロジェクトを組み合わせたマルチプロジェクトとして構成します。
 
 構成に必要なプロジェクトはアプリケーション形態によって異なるため、[各アプリケーション形態のアーキテクチャ](../../../app-architecture/index.md) を参照してください。

--- a/documents/contents/guidebooks/how-to-develop/java/create-project.md
+++ b/documents/contents/guidebooks/how-to-develop/java/create-project.md
@@ -7,7 +7,7 @@ description: バックエンドで動作する Java アプリケーションの 
 
 ## Spring Initializr の利用 {#use-spring-initializr}
 
-各 Gradle プロジェクトの雛型は、 Spring Initializr を利用して作成します。
+各 Gradle Groovy DSL プロジェクトの雛型は、 Spring Initializr を利用して作成します。
 Spring Initializr は Spring Boot を利用するプロジェクトの雛型を簡潔に作成できるツールです。
 [Web サービス :material-open-in-new:](https://start.spring.io/){ target=_blank } を利用する方法や、各種 IDE にプラグインや拡張機能を導入することで IDE 上でも利用できます。
 VS Code の場合、 [Spring Boot Extension Pack :material-open-in-new:](https://marketplace.visualstudio.com/items?itemName=Pivotal.vscode-boot-dev-pack){ target=_blank } が導入済みであれば利用できます。
@@ -21,8 +21,9 @@ Web 画面上の各種設定項目は以下の通りです。
 
 - Project
 
-    プロジェクトのビルドツールを Gradle と Apache Maven から選択します。
-    AlesInfiny Maia OSS Edition ではデフォルトのビルドツールを Gradle としており、以降の説明でも Gradle でビルドすることを前提として解説していますが、 Apache Maven も選択できます。
+    プロジェクトのビルドツールを `Gradle - Groovy` 、 `Gradle - Kotlin` 、 `Maven` から選択します。
+    AlesInfiny Maia OSS Edition ではデフォルトのビルドツールを Gradle Groovy DSL としているため、　Spring Initializr では `Gradle - Groovy` を選択しています。
+    以降の説明でも `Gradle - Groovy` でビルドすることを前提として解説していますが、 `Gradle - Kotlin` や `Maven` も選択できます。
 
 - Language
 
@@ -35,11 +36,11 @@ Web 画面上の各種設定項目は以下の通りです。
     特に考慮点がなければ最新の GA 版を選択することを推奨します。
     選択できる Spring Boot のバージョンは、 [OSS サポート期限内のバージョン :material-open-in-new:](https://spring.io/projects/spring-boot#support){ target=_blank } に限られ、古いバージョンは指定できません。
 
-- Project Meta Data：Artifact
+- Project Metadata：Artifact
 
     プロジェクトの基点のフォルダー名となるプロジェクト名を設定します。
 
-- Project Meta Data：その他
+- Project Metadata：その他
 
     ルートプロジェクトの雛型作成では設定不要 ( 任意 ) です。
 
@@ -55,18 +56,18 @@ Web 画面上の各種設定項目は以下の通りです。
 以下、サブプロジェクト毎に異なる設定項目について説明します。
 その他の項目はルートプロジェクトと同様に設定してください。
 
-- Project Meta Data：Group
+- Project Metadata：Group
 
     対象プロジェクトが含まれるグループ名を設定します。
     対象プロジェクトのパッケージ名は、このグループ名から始まることが想定されます。
     ハイフンなど、パッケージ名に利用不可の文字を指定した場合、パッケージ名としては取り除かれますが、元々使わないことが望ましいです。
 
-- Project Meta Data：Artifact
+- Project Metadata：Artifact
 
     サブプロジェクトの基点のフォルダー名となるプロジェクト名を設定します。
     また、グループ名に続くパッケージ名としても利用されますので、グループ名と同様、パッケージ名の命名規則と合致する名前にすることが望ましいです。
 
-- Project Meta Data：Name
+- Project Metadata：Name
 
     アプリケーション名を設定します。
     この名前は Spring Boot 実行クラス ( Main クラス ) のクラス名やパッケージした際の war や jar 名に利用されます。

--- a/documents/includes/abbreviations.md
+++ b/documents/includes/abbreviations.md
@@ -12,6 +12,7 @@
 *[CSR]: Client Side Rendering
 *[CSRF]: Cross-Site Request Forgery：クロスサイトリクエストフォージェリ。
 *[DI]: Dependency Injection：依存性の注入。
+*[DSL]: Domain Specific Language: ドメイン固有言語。
 *[E2E]: End to end
 *[FaaS]: Function as a Service: サーバーレスでアプリケーション開発ができる環境を提供するクラウドサービス。
 *[GA]: General Availability：正式版、製品版、一般公開版。


### PR DESCRIPTION
## このプルリクエストで実施したこと

- Spring Initializr を利用したプロジェクト作成手順が、Gradle Kotlin DSL の導入と共に更新されていたため、それに追従する形でドキュメントを修正しました。
- これに伴い、単にGradle と記載すると Gradle Groovy DSL と Gradle Kotlin DSL のどちらを利用しているのかが不明瞭になるため、 AlesInfiny Maia OSS Edition で採用している Gradle Groovy DSL との記載に修正しました。
- （以降、Gradle）といった、省略を必要とするドキュメント箇所はありませんでした。
- DSL を略語辞書に登録しました

## このプルリクエストでは実施していないこと

なし

## Issue や Discussions 、関連する Web サイトなどへのリンク

Gradle Groovy DSL との記載のあるページ
公式ページ：https://docs.gradle.org/current/userguide/migrating_from_groovy_to_kotlin_dsl.html
一般ページ：https://blog1.mammb.com/entry/2020/11/14/090000