### PR TITLE
サンプルアプリの起動手順をワークスペース用に変更する

### DIFF
--- a/documents/contents/index.md
+++ b/documents/contents/index.md
@@ -67,9 +67,11 @@ AlesInfiny Maia で構築した Web アプリケーションのサンプルを�
 
     !!! info "npm ci が失敗した場合"
         `npm ci` の途中でエラーや脆弱性情報以外の警告が出た場合、インストールに失敗している可能性があります。
-        その場合は、「dressca\\dressca-frontend\\node_modules」ディレクトリを削除し、再度 `npm ci` を実行してください。
+        その場合は、「dressca\\dressca-frontend\\node_modules」、
+        「dressca\\dressca-frontend\\consumer\\node_modules」ディレクトリをそれぞれ削除し、再度 `npm ci` を実行してください。
 
-1. フロントエンドのアプリケーションを実行するために、 VS Code のターミナルでコマンドを実行します。
+1. フロントエンドのアプリケーションを実行します。
+VS Code のターミナルで、「dressca\\dressca-frontend\\consumer」に移動して以下のコマンドを実行してください。
 アプリケーションの実行方法は、 API 呼び出し時にバックエンドアプリケーションへ実際にアクセスする「開発モード」と、 API 呼び出し時にモックを利用する「モックモード」の 2 種類があります。
 「開発モード」で実行する場合には、後述の手順を参照してバックエンドアプリケーションを先に起動させておく必要があります。
 


### PR DESCRIPTION
## このプルリクエストで実施したこと
既存のサンプルアプリDresscaを、consumerワークスペースに移動したことによる、
サンプルアプリの起動手順への影響について、
ドキュメントの修正が漏れていたため、手順を修正いたします。

1. サンプルアプリを起動する際に、ワークスペース（consumer）フォルダに移動してからnpmスクリプトを実行する手順に修正いたしました。

1. `npm ci`コマンドの実行に失敗した際は、ルートプロジェクト直下とワークスペース配下の両方のnode_modulesを削除してから再実行する手順に修正いたしました。

## このプルリクエストでは実施していないこと

AzureADB2Cについてはnpm workspacesをまだ導入していないため、
こちらのREAME.mdについては修正しておりません。

## Issue や Discussions 、関連する Web サイトなどへのリンク

- https://github.com/AlesInfiny/maia/issues/1214