### PR TITLE
main.tsでpiniaをuseする際の書き方をcreate-vueのテンプレートと揃える

### DIFF
--- a/samples/azure-ad-b2c-sample/auth-frontend/src/main.ts
+++ b/samples/azure-ad-b2c-sample/auth-frontend/src/main.ts
@@ -3,8 +3,7 @@ import { createPinia } from 'pinia';
 import App from './App.vue';
 
 const app = createApp(App);
-const pinia = createPinia();
 
-app.use(pinia);
+app.use(createPinia());
 
 app.mount('#app');

--- a/samples/web-csr/dressca-frontend/consumer/src/main.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/main.ts
@@ -9,9 +9,8 @@ import '@/assets/base.css';
 import '@/config/yup.config';
 
 const app = createApp(App);
-const pinia = createPinia();
 
-app.use(pinia);
+app.use(createPinia());
 app.use(router);
 
 app.use(errorHandlerPlugin);


### PR DESCRIPTION
## この Pull request で実施したこと
main.tsでpiniaをuseする際の書き方をcreate-vueのテンプレートと揃えました。
機能的には変更、影響ございません。
念のためCI以外にアプリの起動のみ確認しております。
また、現時点ではドキュメントへの影響はございませんでした。

### モチベーション
エラーハンドラーの設定のドキュメントにmain.tsの実装例を掲載するにあたり、
サンプルアプリと差分が生じており、不要な混乱を生む可能性があるため、

## この Pull request では実施していないこと
なし

## Issues や Discussions 、関連する Web サイトなどへのリンク
サンプルアプリが追従しているcreate-vue@3.10.4で、
ガイド通りに質問に回答して生成した場合の`main.ts`は下記の通り。
なお、create-vueの最新バージョン3.11.1でも`main.ts`の生成結果は変わらない。

```ts
import './assets/main.css'

import { createApp } from 'vue'
import { createPinia } from 'pinia'

import App from './App.vue'
import router from './router'

const app = createApp(App)

app.use(createPinia())
app.use(router)

app.mount('#app')
```
