### PR TITLE
dependabotの付与するルートディレクトリのnpmパッケージの更新に対するPRのラベルを変更する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,6 @@ updates:
     commit-message:
       prefix: "npm-root"
     labels:
-      - "ドキュメント改善"
       - "npm"
       - "dependencies"
 


### PR DESCRIPTION
## このプルリクエストで実施したこと

dependabotの提出するルートディレクトリにあるnpmパッケージの更新PRに対して付与されていた「ドキュメント改善」のラベルを削除します。

## このプルリクエストでは実施していないこと

なし

## Issue や Discussions 、関連する Web サイトなどへのリンク

なし