### PR TITLE
ルートプロジェクトにモックモードでの起動スクリプトを追加

### DIFF
--- a/documents/contents/guidebooks/how-to-develop/vue-js/setting-workspaces.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/setting-workspaces.md
@@ -50,7 +50,7 @@ CJS 形式のファイルを正しく読み込むために、 `"type": "module"`
 
 ## スクリプトの登録 {#register-npm-scripts}
 
-CI パイプラインで使用するために、ルートプロジェクトの package.json にスクリプトを登録します。
+ルートプロジェクトの package.json にスクリプトを登録します。
 `-w` オプションでワークスペース名を指定することで、指定したワークスペースの package.json に存在するスクリプトを実行できます。
 設定例を下記に示します。
 
@@ -62,7 +62,8 @@ CI パイプラインで使用するために、ルートプロジェクトの p
     "build-only:dev:workspace-name": "npm run build-only:dev -w workspace-name",
     "build:prod:workspace-name": "npm run build:prod -w workspace-name",
     "test:unit:workspace-name": "npm run test:unit -w workspace-name",
-    "dev:workspace-name": "npm run dev -w workspace-name"
+    "dev:workspace-name": "npm run dev -w workspace-name",
+    "mock:workspace-name": "npm run mock -w workspace-name"
   },
 }
 ```

--- a/samples/web-csr/dressca-frontend/package.json
+++ b/samples/web-csr/dressca-frontend/package.json
@@ -9,7 +9,8 @@
     "build-only:dev:consumer": "npm run build-only:dev -w consumer",
     "build:prod:consumer": "npm run build:prod -w consumer",
     "test:unit:consumer": "npm run test:unit -w consumer",
-    "dev:consumer": "npm run dev -w consumer"
+    "dev:consumer": "npm run dev -w consumer",
+    "mock:consumer": "npm run mock -w consumer"
   },
   "workspaces": [
     "consumer"


### PR DESCRIPTION
## この Pull request で実施したこと
ルートプロジェクトのpackage.jsonにmockモードでの起動スクリプトを追加しました。
ルートプロジェクトに登録するnpmスクリプトは必ずしもCIでの使用を目的とするわけではないので、
ドキュメント上の不正確な記述を削除しました。
ドキュメント上のpackage.jsonのサンプルを掲載している箇所に変更を反映しました。

### 確認ポイント
カレントディレクトリをルートプロジェクトにして`npm run mock:consumer`を実行した際に、モックモードでアプリが正常に起動すること。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし
