### PR TITLE
ドキュメント作成手順の目次構造を修正する

### DIFF
--- a/documents/README.md
+++ b/documents/README.md
@@ -1,6 +1,6 @@
 <!-- textlint-disable @textlint-rule/require-header-id -->
 <!-- markdownlint-disable-file CMD001 -->
-<!-- cspell:ignore hoge hogehoge -->
+<!-- cspell:ignore hoge -->
 # AlesInfiny Maia OSS Edition ドキュメントについて
 
 ## 本番環境


### PR DESCRIPTION
## この Pull request で実施したこと

- 常時参照する規約類がドキュメントの前半に来るように再配置しました。
- ドキュメント開発には直接的に関係のない拡張機能の記載を削除しました。
- cspellの利用方法について、重複した記載を削除しました

## この Pull request では実施していないこと

ドキュメントのLintに関する修正は行っていません。
以下のIssueで対応予定です。

https://github.com/AlesInfiny/maia/issues/1005

## Issues や Discussions 、関連する Web サイトなどへのリンク

https://github.com/AlesInfiny/maia/issues/1005