### PR TITLE
型チェックのコマンドの綴りをtypecheckからtype-checkに変更

### DIFF
--- a/.github/workflows/samples-dressca-consumer-frontend.ci.yml
+++ b/.github/workflows/samples-dressca-consumer-frontend.ci.yml
@@ -56,7 +56,7 @@ jobs:
 
       - id: run-type-check
         name: TypeScript の型チェック
-        run: npm run type-check:consumer >> /var/tmp/typecheck-result.txt 2>&1
+        run: npm run type-check:consumer >> /var/tmp/type-check-result.txt 2>&1
 
       - id: application-build
         name: アプリケーションのビルド
@@ -77,7 +77,7 @@ jobs:
         if: ${{ success() || (failure() && steps.run-type-check.conclusion == 'failure') }}
         uses: ./.github/workflows/file-to-summary
         with:
-          body: /var/tmp/typecheck-result.txt
+          body: /var/tmp/type-check-result.txt
           header: '型チェックの結果 :pencil2:'
 
       - name: ビルドの結果出力

--- a/documents/contents/guidebooks/how-to-develop/vue-js/project-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/project-settings.md
@@ -137,7 +137,7 @@ Project Reference 機能については [Project References :material-open-in-ne
           "scripts": {
             "build": "run-p type-check \"build-only {@}\" --",
             "build-only": "vite build",
-            "typecheck": "vue-tsc --build --force"
+            "type-check": "vue-tsc --build --force"
           }
         }
         ```

--- a/samples/azure-ad-b2c-sample/auth-frontend/.vscode/settings.json
+++ b/samples/azure-ad-b2c-sample/auth-frontend/.vscode/settings.json
@@ -30,7 +30,6 @@
     "pinia",
     "rushstack",
     "stylelint",
-    "typecheck",
     "vite"
   ]
 }


### PR DESCRIPTION
## この Pull request で実施したこと

型チェックのコマンドの綴りをtypecheckからtype-checkに変更した際、
修正が漏れていた下記の箇所についてtype-checkに修正いたしました。
- CIワークフロー上のファイル名
- ドキュメント上のサンプルコード
- cspellの除外設定

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

過去、create-vueのテンプレートはtypecheckでしたが、
create-vue側でのテンプレートもtype-checkに変更済みのため、type-checkに修正しました。