### PR TITLE
Markdownlintの検査からISSUE_TEMPLATEとプルリクエストテンプレートを除外するように変更

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -8,4 +8,5 @@ gitignore: true
 # Github の Issues や Pull requests に設定の Tag が含まれることを防ぐため yaml 上で除外設定を実行する
 globs:
   - "**/*.md"
-  - "!**/.github/**/*.md"
+  - "!**/.github/ISSUE_TEMPLATE/**/*.md"
+  - "!**/.github/pull_request_template.md"


### PR DESCRIPTION
## この Pull request で実施したこと

- Issueテンプレートとプルリクエストテンプレートに対してmarkdownlintが動作しないように設定
- 上記以外の.githubフォルダーのマークダウンファイルに対してmarkdownlintが実行されるように修正

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし