### PR TITLE
ログ・スタックトレースにファイル添付できるようにする

### DIFF
--- a/.github/ISSUE_TEMPLATE/10-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/10-bug-report.yml
@@ -51,7 +51,6 @@ body:
     attributes:
       label: ログ・スタックトレース
       description: スタックトレースなど、アプリケーションやビルドシステムの出力するログを添付してください。
-      render: text
   - type: checkboxes
     id: confirmation
     attributes:


### PR DESCRIPTION
## この Pull request で実施したこと

不具合の報告のテンプレートでログ・スタックトレースの項目にファイルアップロードできるように設定しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- <https://github.com/AlesInfiny/maia/issues/1009>