### PR TITLE
汎用Issueテンプレート利用時、not triagedのラベルを自動で付与するように変更

### DIFF
--- a/.github/ISSUE_TEMPLATE/80-general-issue.md
+++ b/.github/ISSUE_TEMPLATE/80-general-issue.md
@@ -3,7 +3,7 @@ name: （汎用）機能および課題の提案
 about: 汎用的な機能および課題を提案するテンプレートです。
 title: ''
 description: ''
-labels: ''
+labels: not triaged
 assignees: ''
 ---
 


### PR DESCRIPTION
## この Pull request で実施したこと

汎用Issueテンプレート利用時、not triagedのラベルを自動で付与するように変更しました。
Issue記述時に、削除できることを確認済みです。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし