### PR TITLE
WebサイトからGitHubリポジトリにリンクする

### DIFF
--- a/documents/mkdocs.yml
+++ b/documents/mkdocs.yml
@@ -9,6 +9,7 @@ site_description: 'AlesInfiny Maia OSS Edition のポータルサイトです。
 site_dir: build-artifacts
 repo_name: AlesInfiny/maia
 repo_url: https://github.com/AlesInfiny/maia
+edit_uri: edit/main/documents/contents/
 
 # yamllint disable rule:comments-indentation
 nav:
@@ -117,6 +118,7 @@ theme:
   custom_dir: overrides
   favicon: assets/images/favicon.png
   features:
+    - content.action.view
     - content.code.annotate
     - navigation.indexes
     - navigation.instant
@@ -128,6 +130,7 @@ theme:
     code: Source Code Pro
   icon:
     repo: fontawesome/brands/github
+    view: material/eye
   language: ja
   logo: assets/maia-logo.png
   palette:


### PR DESCRIPTION
## この Pull request で実施したこと

ヘッダー部にGitHubリポジトリへのリンクを追加しました。
各ページの右上にGitHubのRawページへのリンクを追加しました。

<img width="711" alt="image" src="https://github.com/user-attachments/assets/ba083858-0873-4551-9e4e-5dfd3bb7813a">

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- <https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/#repository>
- #616 