### PR TITLE
batchの出力ファイルをGitのトラッキングから除外

### DIFF
--- a/samples/web-csr/dressca-backend/batch/.gitignore
+++ b/samples/web-csr/dressca-backend/batch/.gitignore
@@ -1,6 +1,7 @@
 HELP.md
 .gradle
 build/
+output/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/


### PR DESCRIPTION
## この Pull request で実施したこと

batchのテストおよびアプリ実行時に出力されるcsvファイルをGitのトラッキングから除外しました。
これにより、Gitのトラッキングから除外され、ビルドやテストするごとに手動で変更を破棄する必要がなくなります。

以下のように、正常にoutputフォルダーが除外され、グレーアウトしていることがわかります。
![image](https://github.com/user-attachments/assets/18822394-4237-4fd3-a621-2d2dd6047073)


## この Pull request では実施していないこと

特になし。

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #1339
