### PR TITLE
cspellの対象から.gitフォルダー、drawioファイル、svgファイルを除外

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,6 +1,7 @@
 {
     "ignorePaths": [
         ".vscode",
+        ".git",
         ".gitattributes",
         ".gitignore",
         ".markdownlint-cli2.yaml",
@@ -12,6 +13,7 @@
         "LICENSE",
         "LICENSE-CODE",
         "maia.code-workspace",
+        "mkdocs.yml",
         "package-lock.json",
         "package.json",
         "requirements.txt",
@@ -21,7 +23,8 @@
         "**/iis-files/**",
         "**/node_modules/**",
         "**/openapitools.json",
-        "mkdocs.yml",
+        "**/*.drawio",
+        "**/*.svg",
     ],
     "words": [
         "Adoptium",


### PR DESCRIPTION
## この Pull request で実施したこと

cspellの対象から以下を除外しました。

- .git フォルダー配下のファイル
- *.drawio ファイル
- *.svg ファイル

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし