### PR TITLE
OpenAPI Generatorで使用するJDKの下限を修正

### DIFF
--- a/documents/contents/guidebooks/how-to-develop/vue-js/create-api-client-code.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/create-api-client-code.md
@@ -13,7 +13,7 @@ description: Vue.js を用いた クライアントサイドアプリケーシ�
 
 ### JDK のインストール {#install-jdk}
 
-OpenAPI Generator を使用するためには、 Java 8 以降のランタイムと、システム環境変数 JAVA_HOME の設定が必要です。 Oracle JDK や Eclipse Temurin など、適当な JDK をインストールし、 JAVA_HOME を設定してください。
+OpenAPI Generator を使用するためには、 Java 11 以降のランタイムと、システム環境変数 JAVA_HOME の設定が必要です。 Oracle JDK や Eclipse Temurin など、適当な JDK をインストールし、 JAVA_HOME を設定してください。
 
 ## Axios {#axios}
 


### PR DESCRIPTION
## この Pull request で実施したこと

- ドキュメントのOpen API 仕様書からのクライアントコード生成に記述されている、Open API Generator で使用されるJDKのバージョンを正しいものに修正しました。（「 Java 8」⇒「Java 11」）

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #1736 
