### PR TITLE
Code scanning alertsのDisabled Spring CSRF protectionに対応 

### DIFF
--- a/samples/azure-ad-b2c-sample/auth-backend/web/src/main/java/com/dressca/web/security/WebSecurityConfig.java
+++ b/samples/azure-ad-b2c-sample/auth-backend/web/src/main/java/com/dressca/web/security/WebSecurityConfig.java
@@ -38,7 +38,6 @@ public class WebSecurityConfig {
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
     http.securityMatcher("/api/**")
-        .csrf(csrf -> csrf.disable())
         .cors(cors -> cors.configurationSource(request -> {
           CorsConfiguration conf = new CorsConfiguration();
           conf.setAllowCredentials(true);

--- a/samples/web-csr/dressca-backend/web/src/main/java/com/dressca/web/security/WebSecurityConfig.java
+++ b/samples/web-csr/dressca-backend/web/src/main/java/com/dressca/web/security/WebSecurityConfig.java
@@ -31,7 +31,9 @@ public class WebSecurityConfig {
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http
         .securityMatcher("/api/**")
-        .csrf(csrf -> csrf.disable())
+        // CSRF トークンを利用したリクエストの検証を無効化（ OAuth2.0 による認証認可を利用する前提のため）
+        // OAuth2.0 によるリクエストの検証を利用しない場合は、有効化して CSRF 対策を施す
+        .csrf(csrf -> csrf.ignoringRequestMatchers("/api/*"))
         .cors(cors -> cors.configurationSource(request -> {
           CorsConfiguration conf = new CorsConfiguration();
           conf.setAllowCredentials(true);

--- a/samples/web-csr/dressca-backend/web/src/main/java/com/dressca/web/security/WebSecurityConfig.java
+++ b/samples/web-csr/dressca-backend/web/src/main/java/com/dressca/web/security/WebSecurityConfig.java
@@ -33,7 +33,7 @@ public class WebSecurityConfig {
         .securityMatcher("/api/**")
         // CSRF トークンを利用したリクエストの検証を無効化（ OAuth2.0 による認証認可を利用する前提のため）
         // OAuth2.0 によるリクエストの検証を利用しない場合は、有効化して CSRF 対策を施す
-        .csrf(csrf -> csrf.ignoringRequestMatchers("/api/*"))
+        .csrf(csrf -> csrf.ignoringRequestMatchers("/api/**"))
         .cors(cors -> cors.configurationSource(request -> {
           CorsConfiguration conf = new CorsConfiguration();
           conf.setAllowCredentials(true);


### PR DESCRIPTION
## この Pull request で実施したこと

Code scanning alertsのDisabled Spring CSRF protectionに対応するために WebSecurityConfig.java を修正しました。

## この Pull request では実施していないこと

なし。

## Issues や Discussions 、関連する Web サイトなどへのリンク

- https://github.com/AlesInfiny/maia/issues/1770
- https://github.com/AlesInfiny/maia/security/code-scanning/13
