### PR TITLE
ワークフローのサードパーティーアクションのバージョンをコミットハッシュで固定する

### DIFF
--- a/.github/workflows/back-sample-pull-request-ut.yml
+++ b/.github/workflows/back-sample-pull-request-ut.yml
@@ -62,12 +62,12 @@ jobs:
           echo ':x: ビルドまたはテストに失敗しました。' >> $GITHUB_STEP_SUMMARY
 
       - name: JUnitレポート
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v62516aa379bff6370c95fd5894d5a27fb6619d9b  # v5.2.0
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 
       - name: Report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5  # v1.9.1
         if: always()
         with:
           name: Maven Tests

--- a/.github/workflows/back-sample-pull-request-ut.yml
+++ b/.github/workflows/back-sample-pull-request-ut.yml
@@ -62,7 +62,7 @@ jobs:
           echo ':x: ビルドまたはテストに失敗しました。' >> $GITHUB_STEP_SUMMARY
 
       - name: JUnitレポート
-        uses: mikepenz/action-junit-report@v62516aa379bff6370c95fd5894d5a27fb6619d9b  # v5.2.0
+        uses: mikepenz/action-junit-report@62516aa379bff6370c95fd5894d5a27fb6619d9b  # v5.2.0
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 

--- a/.github/workflows/build-and-release-documents.yml
+++ b/.github/workflows/build-and-release-documents.yml
@@ -106,7 +106,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: ステージング環境へのデプロイ
-        uses: azure/webapps-deploy@2fdd5c3ebb4e540834e86ecc1f6fdcd5539023ee  # v3.0.2
+        uses: azure/webapps-deploy@de617f46172a906d0617bb0e50d81e9e3aec24c8  # v3.0.1
         with:
           app-name: ${{ env.APP_ALESINFINY_MAIA_WEBAPP_NAME }}
           slot-name: staging

--- a/.github/workflows/build-and-release-documents.yml
+++ b/.github/workflows/build-and-release-documents.yml
@@ -81,7 +81,7 @@ jobs:
           name: documents
 
       - name: Githubのリリース
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048  # v2.2.0
         with:
           files: ${{ env.DOCUMENT_ARTIFACTS_FILENAME }}
           generate_release_notes: true
@@ -99,21 +99,21 @@ jobs:
           name: documents
 
       - name: Azure に OIDC Login
-        uses: azure/login@v2
+        uses: azure/login@a65d910e8af852a8061c627c456678983e180302  # v2.2.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: ステージング環境へのデプロイ
-        uses: azure/webapps-deploy@v3
+        uses: azure/webapps-deploy@2fdd5c3ebb4e540834e86ecc1f6fdcd5539023ee  # v3.0.2
         with:
           app-name: ${{ env.APP_ALESINFINY_MAIA_WEBAPP_NAME }}
           slot-name: staging
           package: "${{ env.DOCUMENT_ARTIFACTS_FILENAME }}"
 
       - name: Teams への通知
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@23ad54bcd1178fcff6a0d17538fa09de3a7f0a4d  # v1.16.4
         with:
           url: ${{ secrets.ALESINFINY_POST_MESSAGE_TO_TEAMS_URL  }}
           method: POST
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 本番環境への反映承認
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@23ad54bcd1178fcff6a0d17538fa09de3a7f0a4d  # v1.16.4
         with:
           url: ${{ secrets.ALESINFINY_APPROVE_REQUEST_TO_TEAMS_URL  }}
           method: POST

--- a/.github/workflows/check-openapi-generator-update.yml
+++ b/.github/workflows/check-openapi-generator-update.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: GitHub API経由でリポジトリの情報を取得
         id: get-repo-info-via-github-api
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@23ad54bcd1178fcff6a0d17538fa09de3a7f0a4d  # v1.16.4
         with:
           url: 'https://api.github.com/repos/OpenAPITools/openapi-generator/releases/latest'
           method: 'GET'
@@ -59,7 +59,7 @@ jobs:
       - name: issue を作成
         id: create-issue
         if: ${{ steps.check-version-update.outputs.update-required == 'true' }}
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@ffdd254f4eaf1562b8a2c66aeaa37f1ff2231179  # v3.7.3
         with:
           action: dblock/create-a-github-issue@v3
           with: |

--- a/.github/workflows/remove-old-artifacts.yml
+++ b/.github/workflows/remove-old-artifacts.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: 古いアーティファクトの削除
-        uses: c-hive/gha-remove-artifacts@v1
+        uses: c-hive/gha-remove-artifacts@44fc7acaf1b3d0987da0e8d4707a989d80e9554b  # v1.4.0
         with:
           age: '{{ github.event.inputs.target }} days'
           skip-tags: true

--- a/.github/workflows/samples-azure-ad-b2c-ci.yml
+++ b/.github/workflows/samples-azure-ad-b2c-ci.yml
@@ -140,12 +140,12 @@ jobs:
           echo ':x: コンパイルまたは静的テストに失敗しました。' >> $GITHUB_STEP_SUMMARY
 
       - name: JUnitレポート
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v62516aa379bff6370c95fd5894d5a27fb6619d9b  # v5.2.0
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 
       - name: Report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5  # v1.9.1
         if: always()
         with:
           name: Maven Tests

--- a/.github/workflows/samples-azure-ad-b2c-ci.yml
+++ b/.github/workflows/samples-azure-ad-b2c-ci.yml
@@ -140,7 +140,7 @@ jobs:
           echo ':x: コンパイルまたは静的テストに失敗しました。' >> $GITHUB_STEP_SUMMARY
 
       - name: JUnitレポート
-        uses: mikepenz/action-junit-report@v62516aa379bff6370c95fd5894d5a27fb6619d9b  # v5.2.0
+        uses: mikepenz/action-junit-report@62516aa379bff6370c95fd5894d5a27fb6619d9b  # v5.2.0
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 


### PR DESCRIPTION
## この Pull request で実施したこと

- ワークフローで利用しているサードパーティーのアクションをコミットハッシュを使って指定するように修正しました。
コミットハッシュでアクションのバージョンを固定することで、サプライチェーン攻撃によって意図しないアクションが実行されることを防ぎます。

- `mikepenz/action-junit-report` は元々 v4 が指定されていましたが、最新のメジャーバージョンが v5 であるため動作確認の上 v5 に変更しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
