### PR TITLE
(ADB2C)Spring Boot 3.4対応

### DIFF
--- a/samples/azure-ad-b2c-sample/README.md
+++ b/samples/azure-ad-b2c-sample/README.md
@@ -246,8 +246,8 @@ Azure AD B2C に追加したユーザーは、以下の手順で削除できま�
 
     ```gradle
     ext {
-      activeDirectoryVersion = "[使用するライブラリのバージョン番号を記述。サンプルでは 5.11.0]"
-      springCloudAzureVersion = "[使用するライブラリのバージョン番号を記述。サンプルでは 5.11.0]"
+      activeDirectoryVersion = "[使用するライブラリのバージョン番号を記述。サンプルでは 5.19.0]"
+      springCloudAzureVersion = "[使用するライブラリのバージョン番号を記述。サンプルでは 5.19.0]"
 
       supportDependencies = [
         spring_cloud_azure_starter : "com.azure.spring:spring-cloud-azure-starter",

--- a/samples/azure-ad-b2c-sample/auth-backend/api-docs/api-specification.json
+++ b/samples/azure-ad-b2c-sample/auth-backend/api-docs/api-specification.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.1.0",
   "info": {
     "description": "Azure AD B2Cを利用したユーザー認証機能を提供するサンプルアプリケーションです。",
     "title": "Azure AD B2C ユーザー認証",
@@ -88,52 +88,66 @@
         "type": "object",
         "properties": {
           "detail": {
-            "type": "string"
+            "type": [
+              "string"
+            ]
           },
           "instance": {
-            "type": "string",
+            "type": [
+              "string"
+            ],
             "format": "uri"
           },
           "properties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object"
-            }
+            "type": [
+              "object"
+            ],
+            "additionalProperties": {}
           },
           "status": {
-            "type": "integer",
+            "type": [
+              "integer"
+            ],
             "format": "int32"
           },
           "title": {
-            "type": "string"
+            "type": [
+              "string"
+            ]
           },
           "type": {
-            "type": "string",
+            "type": [
+              "string"
+            ],
             "format": "uri"
           }
         }
       },
       "TimeResponse": {
-        "required": [
-          "serverTime"
-        ],
         "type": "object",
         "properties": {
           "serverTime": {
-            "type": "string"
+            "type": [
+              "string"
+            ]
           }
-        }
+        },
+        "required": [
+          "serverTime"
+        ]
       },
       "UserResponse": {
-        "required": [
-          "userId"
-        ],
         "type": "object",
         "properties": {
           "userId": {
-            "type": "string"
+            "type": [
+              "string"
+            ]
           }
-        }
+        },
+        "required": [
+          "userId"
+        ]
       }
     },
     "securitySchemes": {

--- a/samples/azure-ad-b2c-sample/auth-backend/build.gradle
+++ b/samples/azure-ad-b2c-sample/auth-backend/build.gradle
@@ -44,7 +44,7 @@ subprojects {
     toolVersion = '0.8.12'
   }
   checkstyle {
-    toolVersion = '10.18.2'
+    toolVersion = '10.21.1'
     configDirectory = rootProject.file('config/checkstyle')
   } 
   spotbugs {

--- a/samples/azure-ad-b2c-sample/auth-backend/dependencies.gradle
+++ b/samples/azure-ad-b2c-sample/auth-backend/dependencies.gradle
@@ -1,14 +1,14 @@
 ext {
     // -- PLUGINS
-    springBootVersion = "3.3.4"
-    springDependencyManagementVersion = "1.1.6"
+    springBootVersion = "3.4.1"
+    springDependencyManagementVersion = "1.1.7"
     springdocOpenapiGradlePluginVersion = "1.9.0"
-    spotbugsVersion = "6.0.24"
+    spotbugsVersion = "6.0.27"
 
     // -- DEPENDENCIES
-    springdocOpenapiVersion = "2.6.0"
-    activeDirectoryVersion = "5.16.0"
-    springCloudAzureVersion = "5.16.0"
+    springdocOpenapiVersion = "2.8.1"
+    activeDirectoryVersion = "5.19.0"
+    springCloudAzureVersion = "5.19.0"
 
     supportDependencies = [
         spring_boot_starter : "org.springframework.boot:spring-boot-starter",

--- a/samples/azure-ad-b2c-sample/auth-frontend/app/src/generated/api-client/models/problem-detail.ts
+++ b/samples/azure-ad-b2c-sample/auth-frontend/app/src/generated/api-client/models/problem-detail.ts
@@ -34,10 +34,10 @@ export interface ProblemDetail {
     'instance'?: string;
     /**
      * 
-     * @type {{ [key: string]: object; }}
+     * @type {{ [key: string]: any; }}
      * @memberof ProblemDetail
      */
-    'properties'?: { [key: string]: object; };
+    'properties'?: { [key: string]: any; };
     /**
      * 
      * @type {number}


### PR DESCRIPTION
## この Pull request で実施したこと

Spring Boot 3.4 対応を実施しました。
OpenAPI仕様書の再生成とクライアントコードの再生成をあわせて実行しました。

また、rootのgradleに記載されている各ライブラリのtoolVersionを最新に更新しました。
対応が必要なライブラリはCheckstyleのみでした。
- https://checkstyle.sourceforge.io/releasenotes.html
- https://github.com/spotbugs/spotbugs-gradle-plugin?tab=readme-ov-file#spotbugs-version-mapping
- https://docs.gradle.org/current/userguide/jacoco_plugin.html#sec:configuring_the_jacoco_plugin

## この Pull request では実施していないこと

```
[openapi-client:generate] [main] WARN  o.o.codegen.DefaultCodegen - Generation using 3.1.0 specs is in development and is not officially supported yet. If you would like to expedite development, please consider working on the open issues in the 3.1.0 project: https://github.com/orgs/OpenAPITools/projects/4/views/1 and reach out to our team on Slack at https://join.slack.com/t/openapi-generator/shared_invite/zt-12jxxd7p2-XUeQM~4pzsU9x~eGLQqX2g
```

クライアントコード生成時に上記の警告が発生していますが、

- プロジェクト上では上記警告のタスクがクローズされていること
- 特に問題なくアプリケーションが動作していること

から、特に対応していません。

## Issues や Discussions 、関連する Web サイトなどへのリンク

- https://github.com/AlesInfiny/maia/issues/1669
- https://github.com/AlesInfiny/maia/issues/1725
