### PR TITLE
Dresscaの管理アプリの導入に当たってクイックスタートの記述を変更する

### DIFF
--- a/documents/contents/index.md
+++ b/documents/contents/index.md
@@ -102,7 +102,7 @@ VS Code のターミナルで、「dressca\\dressca-frontend\\consumer」に移�
 
 1. 前手順と同様に、サイドバーの「 GRADLE PROJECTS 」タブから以下のタスクを実行します。
 
-    dressca-backend > Tasks > application > bootRunDev
+    web-consumer > Tasks > application > bootRunDev
 
 1. 以下のアドレスで、サンプルアプリケーションの API にアクセスできます。
 


### PR DESCRIPTION
## この Pull request で実施したこと

ドキュメントのトップページに記載されている Dressca のバックエンドの起動方法を管理アプリの導入に合わせて修正しました。
具体的には、 web-consumer の bootRunDev タスクを走らせるように変更しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #1735 
