### PR TITLE
買い物かご画面から不要な表示を削除する

### DIFF
--- a/samples/web-csr/dressca-frontend/consumer/src/views/basket/BasketView.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/basket/BasketView.vue
@@ -166,9 +166,6 @@ onUnmounted(async () => {
         <span class="text-2xl font-medium">
           {{ t('noItemsInBasket') }}
         </span>
-        <span class="text-2xl font-medium">
-          {{ t('noItemsInBasket') }}
-        </span>
       </div>
       <div v-if="!isEmpty()" class="mt-8 mx-2">
         <span class="text-2xl font-medium">現在のカートの中身</span>


### PR DESCRIPTION
## この Pull request で実施したこと

買い物かご画面において、買い物かごが空の場合に「買い物かごに商品がありません。」が二重で表示されていた。
該当箇所であるBasketView.vueを修正した。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし
