### PR TITLE
mockで設定するロール文字列を修正

### DIFF
--- a/samples/web-csr/dressca-frontend/admin/mock/handlers/users.ts
+++ b/samples/web-csr/dressca-frontend/admin/mock/handlers/users.ts
@@ -1,10 +1,11 @@
 import { HttpResponse, http } from 'msw';
 import type { GetLoginUserResponse } from '@/generated/api-client';
 import { HttpStatusCode } from 'axios';
+import { Roles } from '@/shared/constants/roles';
 
 const user: GetLoginUserResponse = {
   userName: 'admin@example.com',
-  roles: ['Admin'],
+  roles: [Roles.ADMIN],
 };
 
 export const usersHandlers = [


### PR DESCRIPTION
## この Pull request で実施したこと

下記の対応時に、mockで設定するロール文字列に不整合が生じており、
画面表示が想定通りでなくなっていたため、修正します。

- https://github.com/AlesInfiny/maia/pull/1798
- 正：`ROLE_ADMIN` 誤：`Admin` 

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし
