### PR TITLE
AzureADB2C サンプルにグローバルエラーハンドラーを導入

### DIFF
--- a/samples/azure-ad-b2c-sample/auth-frontend/app/src/main.ts
+++ b/samples/azure-ad-b2c-sample/auth-frontend/app/src/main.ts
@@ -1,9 +1,12 @@
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import App from './App.vue';
+import { globalErrorHandler } from './shared/error-handler/global-error-handler';
 
 const app = createApp(App);
 
 app.use(createPinia());
+
+app.use(globalErrorHandler);
 
 app.mount('#app');

--- a/samples/azure-ad-b2c-sample/auth-frontend/app/src/shared/error-handler/global-error-handler.ts
+++ b/samples/azure-ad-b2c-sample/auth-frontend/app/src/shared/error-handler/global-error-handler.ts
@@ -1,0 +1,30 @@
+import type { App, ComponentPublicInstance } from 'vue';
+
+export const globalErrorHandler = {
+  /* eslint no-param-reassign: 0 */
+  install(app: App) {
+    app.config.errorHandler = (
+      err: unknown,
+      instance: ComponentPublicInstance | null,
+      info: string,
+    ) => {
+      // 本サンプルAPではコンソールへログの出力を行います。
+      // APの要件によってはサーバーやログ収集ツールにログを送信し、エラーを握りつぶすこともあります。
+      /* eslint no-console: 0 */
+      console.log(err, instance, info);
+    };
+
+    // Vue.js 以外のエラー
+    // テストやデバッグ時にエラーの発生を検知するために利用します。
+    window.addEventListener('error', (event) => {
+      /* eslint no-console: 0 */
+      console.log(event);
+    });
+
+    // テストやデバッグ時に予期せぬ非同期エラーの発生を検知するために利用します。
+    window.addEventListener('unhandledrejection', (event) => {
+      /* eslint no-console: 0 */
+      console.log(event);
+    });
+  },
+};


### PR DESCRIPTION
## この Pull request で実施したこと

- ガイドに従って、AzureADB2Cサンプルのフロントエンドにグローバルエラーハンドラーを導入しました。

### 確認した点
- エラーの発生時に、開発者ツールからコンソールにエラーが出力されることを確認しました。
    - `unhandledrejection` イベントについては手動で発生させて出力を確認しました。
    ```ts
    Promise.reject(new Error("Unhandled rejection error!"));
    ```

## この Pull request では実施していないこと
- DresscaではVueアプリ内でエラーを検知した場合、エラーページへの遷移を行っていますが、AzureADB2Cサンプルではエラーページの実装やエラーページへの画面遷移の実装は行っておりません。

## Issues や Discussions 、関連する Web サイトなどへのリンク

[グローバルエラーハンドラーの設定](https://maia.alesinfiny.org/guidebooks/how-to-develop/vue-js/error-handler-settings/#global-error-handler-setting)
