### PR TITLE
Azure AD B2C 認証サンプルで、 Spring Cloud Azure のバージョン管理に BOM を使用するよう修正

### DIFF
--- a/samples/azure-ad-b2c-sample/auth-backend/dependencies.gradle
+++ b/samples/azure-ad-b2c-sample/auth-backend/dependencies.gradle
@@ -7,7 +7,6 @@ ext {
 
     // -- DEPENDENCIES
     springdocOpenapiVersion = "2.8.1"
-    activeDirectoryVersion = "5.19.0"
     springCloudAzureVersion = "5.19.0"
 
     supportDependencies = [
@@ -19,7 +18,7 @@ ext {
         springdoc_openapi_starter_webmvc_ui : "org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocOpenapiVersion",
 
         spring_cloud_azure_starter : "com.azure.spring:spring-cloud-azure-starter",
-        spring_cloud_azure_starter_ad_b2c : "com.azure.spring:spring-cloud-azure-starter-active-directory-b2c:$activeDirectoryVersion",
+        spring_cloud_azure_starter_ad_b2c : "com.azure.spring:spring-cloud-azure-starter-active-directory-b2c",
         spring_cloud_azure_dependencies : "com.azure.spring:spring-cloud-azure-dependencies:$springCloudAzureVersion",
         spring_security_test : 'org.springframework.security:spring-security-test',
 


### PR DESCRIPTION
## この Pull request で実施したこと

- Azure AD B2C 認証サンプルで、 Spring Cloud Azure のバージョン管理に BOM を使用するよう修正しました。

## この Pull request では実施していないこと

- 既に依存関係を解決するためのBOMとして、spring cloud azure dependencies の読み込みは行われていたため、追記は行っていません。

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #1787 