### PR TITLE
楽観ロックエラーのメッセージを削除にも対応するように修正

### DIFF
--- a/samples/web-csr/dressca-backend/application-core/src/main/java/com/dressca/applicationcore/applicationservice/CatalogApplicationService.java
+++ b/samples/web-csr/dressca-backend/application-core/src/main/java/com/dressca/applicationcore/applicationservice/CatalogApplicationService.java
@@ -189,15 +189,16 @@ public class CatalogApplicationService {
       throws PermissionDeniedException, CatalogNotFoundException, OptimisticLockingFailureException {
     apLog.debug(messages.getMessage(MessageIdConstants.D_CATALOG_DELETE_ITEM_FROM_CATALOG, new Object[] { id },
         Locale.getDefault()));
+    final String operationName = "deleteItemFromCatalog";
     if (!this.userStore.isInRole(UserRoleConstants.ADMIN)) {
-      throw new PermissionDeniedException("deleteItemFromCatalog");
+      throw new PermissionDeniedException(operationName);
     }
     if (!this.catalogDomainService.existCatalogItem(id)) {
       throw new CatalogNotFoundException(id);
     }
     int deleteRowCount = this.catalogRepository.remove(id, rowVersion);
     if (deleteRowCount == 0) {
-      throw new OptimisticLockingFailureException(id);
+      throw new OptimisticLockingFailureException(id, operationName);
     }
   }
 
@@ -225,9 +226,9 @@ public class CatalogApplicationService {
 
     apLog.debug(messages.getMessage(MessageIdConstants.D_CATALOG_UPDATE_CATALOG_ITEM, new Object[] { id },
         Locale.getDefault()));
-
+    final String operationName = "updateCatalogItem";
     if (!this.userStore.isInRole(UserRoleConstants.ADMIN)) {
-      throw new PermissionDeniedException("updateCatalogItem");
+      throw new PermissionDeniedException(operationName);
     }
 
     if (!this.catalogDomainService.existCatalogItem(id)) {
@@ -248,7 +249,7 @@ public class CatalogApplicationService {
 
     int updateRowCount = this.catalogRepository.update(item);
     if (updateRowCount == 0) {
-      throw new OptimisticLockingFailureException(id);
+      throw new OptimisticLockingFailureException(id, operationName);
     }
   }
 

--- a/samples/web-csr/dressca-backend/application-core/src/main/java/com/dressca/applicationcore/catalog/OptimisticLockingFailureException.java
+++ b/samples/web-csr/dressca-backend/application-core/src/main/java/com/dressca/applicationcore/catalog/OptimisticLockingFailureException.java
@@ -14,11 +14,11 @@ public class OptimisticLockingFailureException extends LogicException {
    * 
    * @param catalogItemId 更新処理を試みたカタログアイテム ID 。
    */
-  public OptimisticLockingFailureException(long catalogItemId) {
+  public OptimisticLockingFailureException(long catalogItemId, String operationName) {
     super(
         null,
         ExceptionIdConstants.E_OPTIMISTIC_LOCKING_FAILURE,
-        new String[] { String.valueOf(catalogItemId) },
-        new String[] { String.valueOf(catalogItemId) });
+        new String[] { String.valueOf(catalogItemId), operationName },
+        new String[] { String.valueOf(catalogItemId), operationName });
   }
 }

--- a/samples/web-csr/dressca-backend/application-core/src/main/java/com/dressca/applicationcore/constant/ExceptionIdConstants.java
+++ b/samples/web-csr/dressca-backend/application-core/src/main/java/com/dressca/applicationcore/constant/ExceptionIdConstants.java
@@ -38,6 +38,6 @@ public class ExceptionIdConstants {
   /** {0} を実行する権限がありません。 */
   public static final String E_PERMISSION_DENIED = "permissionDenied";
 
-  /** カタログアイテム ID: {0} のカタログアイテムの更新時に楽観ロックエラーが発生しました。 */
+  /** カタログアイテム ID: {0} の {1} 実行時に楽観ロックエラーが発生しました。 */
   public static final String E_OPTIMISTIC_LOCKING_FAILURE = "optimisticLockingFailure";
 }

--- a/samples/web-csr/dressca-backend/application-core/src/main/resources/applicationcore/messages.properties
+++ b/samples/web-csr/dressca-backend/application-core/src/main/resources/applicationcore/messages.properties
@@ -11,7 +11,7 @@ catalogIdNotFound=商品ID: {0} の商品が見つかりませんでした。
 catalogBrandNotFound=ブランドID: {0} のブランドが見つかりませんでした。
 catalogCategoryNotFound=カテゴリID: {0} のカテゴリが見つかりませんでした。
 permissionDenied={0} を実行する権限がありません。
-optimisticLockingFailure=カタログアイテム ID: {0} のカタログアイテムの更新時に楽観ロックエラーが発生しました。
+optimisticLockingFailure=カタログアイテム ID: {0} の {1} 実行時に楽観ロックエラーが発生しました。
 # 通知用メッセージ
 assetApplicationServiceGetAsset=アセット情報{0}を取得します。
 catalogApplicationServiceCountCatalogItems=条件（ブランドID: {0}, カテゴリID: {1}）に一致するカテゴリの件数を取得します。


### PR DESCRIPTION
## この Pull request で実施したこと

- 楽観ロックエラーによってログに出力されるエラーメッセージが、更新処理専用のものになっていたので、削除処理にも対応できるよう修正しました。
- 楽観ロックエラーのコンストラクタの引数に処理名を追加しました。

## この Pull request では実施していないこと

- 特になし。

## Issues や Discussions 、関連する Web サイトなどへのリンク
- #1912 