### PR TITLE
JUnitテストのCIをJUnitレポートに限定

### DIFF
--- a/.github/workflows/back-sample-pull-request-ut.yml
+++ b/.github/workflows/back-sample-pull-request-ut.yml
@@ -65,12 +65,3 @@ jobs:
         uses: mikepenz/action-junit-report@62516aa379bff6370c95fd5894d5a27fb6619d9b  # v5.2.0
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
-
-      - name: Report
-        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5  # v1.9.1
-        if: always()
-        with:
-          name: Maven Tests
-          path: '**/build/test-results/test/TEST-*.xml'
-          reporter: java-junit
-          fail-on-error: true

--- a/.github/workflows/samples-azure-ad-b2c-ci.yml
+++ b/.github/workflows/samples-azure-ad-b2c-ci.yml
@@ -143,12 +143,3 @@ jobs:
         uses: mikepenz/action-junit-report@62516aa379bff6370c95fd5894d5a27fb6619d9b  # v5.2.0
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
-
-      - name: Report
-        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5  # v1.9.1
-        if: always()
-        with:
-          name: Maven Tests
-          path: '**/build/test-results/test/TEST-*.xml'
-          reporter: java-junit
-          fail-on-error: true


### PR DESCRIPTION
## この Pull request で実施したこと

JUnit テストの CI を JUnit レポートに限定するように修正しました。
JUnit テストの検証結果として現時点で mikepenz/action-junit-report と dorny/test-reporter の二つのライブラリを利用しています。
しかし、検証結果の内容が重複していたため、 mikepenz/action-junit-report のみを使用するように変更しました。

 mikepenz/action-junit-report の採用理由は、以下の通りです。
 
- Checks の中にエラーが発生する旨のテキストが表示されること
- dorny/test-reporter のテストレポートが必要以上の内容を出力していたこと


## この Pull request では実施していないこと

v.1.0.0 の段階で mikepenz/action-junit-report のバージョンが5にアップデートされているため、本作業完了後
 #1508 のプルリクエストはクローズします。

JUnit テストレポートで発生している不具合に関しては Github 側の対応を待つ必要があるため対応していません。

## Issues や Discussions 、関連する Web サイトなどへのリンク

検証した Pull request
- #1742
- #1508