### PR TITLE
Spring Security のバージョン指定を削除

### DIFF
--- a/samples/web-csr/dressca-backend/dependencies.gradle
+++ b/samples/web-csr/dressca-backend/dependencies.gradle
@@ -14,7 +14,6 @@ ext {
     springdocOpenapiVersion = "2.8.1"
     servletApiVersion = "6.1.0"
     commonsLangVersion = "3.17.0"
-    springSecurityVersion = "3.4.1"
     mybatisGeneratorVersion = "1.4.2"
 
     supportDependencies = [
@@ -25,7 +24,7 @@ ext {
         spring_boot_starter_validation : "org.springframework.boot:spring-boot-starter-validation",
         spring_boot_starter_web : "org.springframework.boot:spring-boot-starter-web",
         spring_boot_starter_actuator : "org.springframework.boot:spring-boot-starter-actuator",
-        spring_boot_security_starter : "org.springframework.boot:spring-boot-starter-security:$springSecurityVersion",
+        spring_boot_security_starter : "org.springframework.boot:spring-boot-starter-security",
 
         spring_batch_test : "org.springframework.batch:spring-batch-test:$springBatchTestVersion",
         springdoc_openapi_starter_webmvc_ui : "org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocOpenapiVersion",


### PR DESCRIPTION
## この Pull request で実施したこと

Spring Security のバージョン削除を実施しました。

![image](https://github.com/user-attachments/assets/4b22d7e4-0a2d-423c-8c4b-ba5f69de4819)

上記の通り、バージョンを削除した際にも、 Spring Boot Starter のバージョン定義と一致したもので依存関係が登録されていることを確認しました。

Admin, Consumer どちらもビルドが正常終了し、起動も問題ないことを確認しています。

## この Pull request では実施していないこと

なし。

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #1773