### PR TITLE
Dresscaのライブラリのアップデートに合わせてapi仕様書とクライアントコードを再生成

### DIFF
--- a/samples/web-csr/dressca-backend/api-docs/web-admin/api-specification.json
+++ b/samples/web-csr/dressca-backend/api-docs/web-admin/api-specification.json
@@ -50,13 +50,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": [
-                    "object"
-                  ],
+                  "type": "object",
                   "additionalProperties": {
-                    "type": [
-                      "object"
-                    ],
+                    "type": "object",
                     "additionalProperties": {
                       "$ref": "#/components/schemas/Link"
                     }
@@ -65,13 +61,9 @@
               },
               "application/vnd.spring-boot.actuator.v2+json": {
                 "schema": {
-                  "type": [
-                    "object"
-                  ],
+                  "type": "object",
                   "additionalProperties": {
-                    "type": [
-                      "object"
-                    ],
+                    "type": "object",
                     "additionalProperties": {
                       "$ref": "#/components/schemas/Link"
                     }
@@ -80,13 +72,9 @@
               },
               "application/vnd.spring-boot.actuator.v3+json": {
                 "schema": {
-                  "type": [
-                    "object"
-                  ],
+                  "type": "object",
                   "additionalProperties": {
-                    "type": [
-                      "object"
-                    ],
+                    "type": "object",
                     "additionalProperties": {
                       "$ref": "#/components/schemas/Link"
                     }
@@ -123,9 +111,7 @@
             "content": {
               "image/*": {
                 "schema": {
-                  "type": [
-                    "string"
-                  ],
+                  "type": "string",
                   "format": "binary"
                 }
               }
@@ -472,13 +458,19 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "type": "object"
+                }
               },
               "application/vnd.spring-boot.actuator.v2+json": {
-                "schema": {}
+                "schema": {
+                  "type": "object"
+                }
               },
               "application/vnd.spring-boot.actuator.v3+json": {
-                "schema": {}
+                "schema": {
+                  "type": "object"
+                }
               }
             },
             "description": "OK"

--- a/samples/web-csr/dressca-backend/api-docs/web-consumer/api-specification.json
+++ b/samples/web-csr/dressca-backend/api-docs/web-consumer/api-specification.json
@@ -115,9 +115,7 @@
             "content": {
               "image/*": {
                 "schema": {
-                  "type": [
-                    "string"
-                  ],
+                  "type": "string",
                   "format": "binary"
                 }
               }
@@ -419,13 +417,19 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "type": "object"
+                }
               },
               "application/vnd.spring-boot.actuator.v2+json": {
-                "schema": {}
+                "schema": {
+                  "type": "object"
+                }
               },
               "application/vnd.spring-boot.actuator.v3+json": {
-                "schema": {}
+                "schema": {
+                  "type": "object"
+                }
               }
             },
             "description": "OK"
@@ -883,7 +887,9 @@
           },
           "properties": {
             "type": "object",
-            "additionalProperties": {}
+            "additionalProperties": {
+              "type": "object"
+            }
           },
           "status": {
             "type": "integer",

--- a/samples/web-csr/dressca-backend/build.gradle
+++ b/samples/web-csr/dressca-backend/build.gradle
@@ -39,7 +39,7 @@ subprojects {
     toolVersion = '0.8.12'
   }
   checkstyle {
-    toolVersion = '10.21.4'
+    toolVersion = '10.21.1'
     configDirectory = rootProject.file('config/checkstyle')
   } 
   spotbugs {

--- a/samples/web-csr/dressca-backend/build.gradle
+++ b/samples/web-csr/dressca-backend/build.gradle
@@ -39,7 +39,7 @@ subprojects {
     toolVersion = '0.8.12'
   }
   checkstyle {
-    toolVersion = '10.21.1'
+    toolVersion = '10.21.4'
     configDirectory = rootProject.file('config/checkstyle')
   } 
   spotbugs {

--- a/samples/web-csr/dressca-frontend/admin/src/generated/api-client/api/actuator-api.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/generated/api-client/api/actuator-api.ts
@@ -105,7 +105,7 @@ export const ActuatorApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async health(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
+        async health(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.health(options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['ActuatorApi.health']?.[localVarOperationServerIndex]?.url;
@@ -139,7 +139,7 @@ export const ActuatorApiFactory = function (configuration?: Configuration, baseP
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        health(options?: RawAxiosRequestConfig): AxiosPromise<any> {
+        health(options?: RawAxiosRequestConfig): AxiosPromise<object> {
             return localVarFp.health(options).then((request) => request(axios, basePath));
         },
         /**

--- a/samples/web-csr/dressca-frontend/consumer/src/generated/api-client/api/actuator-api.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/generated/api-client/api/actuator-api.ts
@@ -105,7 +105,7 @@ export const ActuatorApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async health(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
+        async health(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.health(options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['ActuatorApi.health']?.[localVarOperationServerIndex]?.url;
@@ -139,7 +139,7 @@ export const ActuatorApiFactory = function (configuration?: Configuration, baseP
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        health(options?: RawAxiosRequestConfig): AxiosPromise<any> {
+        health(options?: RawAxiosRequestConfig): AxiosPromise<object> {
             return localVarFp.health(options).then((request) => request(axios, basePath));
         },
         /**

--- a/samples/web-csr/dressca-frontend/consumer/src/generated/api-client/models/problem-detail.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/generated/api-client/models/problem-detail.ts
@@ -34,10 +34,10 @@ export interface ProblemDetail {
     'instance'?: string;
     /**
      * 
-     * @type {{ [key: string]: any; }}
+     * @type {{ [key: string]: object; }}
      * @memberof ProblemDetail
      */
-    'properties'?: { [key: string]: any; };
+    'properties'?: { [key: string]: object; };
     /**
      * 
      * @type {number}


### PR DESCRIPTION
## この Pull request で実施したこと

- Dresscaのライブラリのアップデートに合わせてapi仕様書とクライアントコードを再生成しました。

以下は実施済みです。
- バックエンドのビルドが正常に完了すること
- フロントエンド側を合わせた打鍵テストが正常に実施出来ること

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #2143 