### PR TITLE
Consumerの不要なルーティング定義を削除

### DIFF
--- a/samples/web-csr/dressca-frontend/consumer/src/router/ordering/ordering.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/router/ordering/ordering.ts
@@ -7,11 +7,6 @@ export const orderingRoutes: RouteRecordRaw[] = [
     component: () => import('@/views/ordering/CheckoutView.vue'),
   },
   {
-    path: '/ordering/done',
-    name: 'ordering/done',
-    component: () => import('@/views/ordering/DoneView.vue'),
-  },
-  {
     path: '/ordering/done/:orderId(\\d+)',
     name: 'ordering/done',
     component: () => import('@/views/ordering/DoneView.vue'),


### PR DESCRIPTION
## この Pull request で実施したこと
Consumerの注文に関するルーティング定義で不要な定義が存在したので削除しました。
以下は確認済みです。
- 該当のルーティング定義を使用している画面が存在しないこと。

## この Pull request では実施していないこと

なし。

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #2186 