### PR TITLE
authentication-guardのチェック対象のパス指定方法をvue-router公式の実装に沿うよう修正

### DIFF
--- a/samples/web-csr/dressca-frontend/admin/src/router/authentication/authentication.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/router/authentication/authentication.ts
@@ -8,5 +8,6 @@ export const authenticationRoutes: RouteRecordRaw[] = [
     path: '/authentication/login',
     name: 'authentication/login',
     component: () => import('@/views/authentication/LoginView.vue'),
+    meta: { requiresAuth: false },
   },
 ];

--- a/samples/web-csr/dressca-frontend/admin/src/router/catalog/catalog.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/router/catalog/catalog.ts
@@ -8,15 +8,18 @@ export const catalogRoutes: RouteRecordRaw[] = [
     path: '/catalog/items',
     name: 'catalog/items',
     component: () => import('@/views/catalog/ItemsView.vue'),
+    meta: { requiresAuth: true },
   },
   {
     path: '/catalog/items/edit/:itemId',
     name: 'catalog/items/edit',
     component: () => import('@/views/catalog/ItemsEditView.vue'),
+    meta: { requiresAuth: true },
   },
   {
     path: '/catalog/items/add',
     name: 'catalog/items/add',
     component: () => import('@/views/catalog/ItemsAddView.vue'),
+    meta: { requiresAuth: true },
   },
 ];

--- a/samples/web-csr/dressca-frontend/admin/src/router/error/error.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/router/error/error.ts
@@ -8,5 +8,6 @@ export const errorRoutes: RouteRecordRaw[] = [
     path: '/error',
     name: 'error',
     component: () => import('@/views/error/ErrorView.vue'),
+    meta: { requiresAuth: false },
   },
 ];

--- a/samples/web-csr/dressca-frontend/admin/src/router/home/home.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/router/home/home.ts
@@ -8,5 +8,6 @@ export const homeRoutes: RouteRecordRaw[] = [
     path: '/',
     name: 'home',
     component: () => import('@/views/home/HomeView.vue'),
+    meta: { requiresAuth: true },
   },
 ];

--- a/samples/web-csr/dressca-frontend/admin/src/shared/authentication/authentication-guard.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/shared/authentication/authentication-guard.ts
@@ -12,20 +12,13 @@ export const authenticationGuard = (router: Router) => {
   router.beforeEach((to) => {
     const authenticationStore = useAuthenticationStore();
     const routingStore = useRoutingStore();
-    const ignoreAuthPaths: (RouteRecordName | null | undefined)[] = [
-      'authentication/login',
-      'error',
-    ];
-    if (ignoreAuthPaths.includes(to.name)) {
-      return true;
+
+    if (to.meta.requiresAuth && !authenticationStore.isAuthenticated) {
+      const redirectFromPath: string = to.fullPath;
+      routingStore.setRedirectFrom(redirectFromPath);
+      return { name: 'authentication/login' };
     }
 
-    if (authenticationStore.isAuthenticated) {
-      return true;
-    }
-
-    const redirectFromPath: string = to.fullPath;
-    routingStore.setRedirectFrom(redirectFromPath);
-    return { name: 'authentication/login' };
+    return true;
   });
 };

--- a/samples/web-csr/dressca-frontend/admin/src/shared/authentication/authentication-guard.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/shared/authentication/authentication-guard.ts
@@ -1,4 +1,4 @@
-import type { Router, RouteRecordName } from 'vue-router';
+import type { Router } from 'vue-router';
 import { useAuthenticationStore } from '@/stores/authentication/authentication';
 import { useRoutingStore } from '@/stores/routing/routing';
 

--- a/samples/web-csr/dressca-frontend/consumer/src/router/authentication/authentication.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/router/authentication/authentication.ts
@@ -5,5 +5,6 @@ export const authenticationRoutes: RouteRecordRaw[] = [
     path: '/authentication/login',
     name: 'authentication/login',
     component: () => import('@/views/authentication/LoginView.vue'),
+    meta: { requiresAuth: false },
   },
 ];

--- a/samples/web-csr/dressca-frontend/consumer/src/router/basket/basket.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/router/basket/basket.ts
@@ -5,5 +5,6 @@ export const basketRoutes: RouteRecordRaw[] = [
     path: '/basket',
     name: 'basket',
     component: () => import('@/views/basket/BasketView.vue'),
+    meta: { requiresAuth: false },
   },
 ];

--- a/samples/web-csr/dressca-frontend/consumer/src/router/catalog/catalog.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/router/catalog/catalog.ts
@@ -5,5 +5,6 @@ export const catalogRoutes: RouteRecordRaw[] = [
     path: '/',
     name: 'catalog',
     component: () => import('@/views/catalog/CatalogView.vue'),
+    meta: { requiresAuth: false },
   },
 ];

--- a/samples/web-csr/dressca-frontend/consumer/src/router/error/error.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/router/error/error.ts
@@ -5,5 +5,6 @@ export const errorRoutes: RouteRecordRaw[] = [
     path: '/error',
     name: 'error',
     component: () => import('@/views/error/ErrorView.vue'),
+    meta: { requiresAuth: false },
   },
 ];

--- a/samples/web-csr/dressca-frontend/consumer/src/router/ordering/ordering.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/router/ordering/ordering.ts
@@ -5,16 +5,19 @@ export const orderingRoutes: RouteRecordRaw[] = [
     path: '/ordering/checkout',
     name: 'ordering/checkout',
     component: () => import('@/views/ordering/CheckoutView.vue'),
+    meta: { requiresAuth: true },
   },
   {
     path: '/ordering/done',
     name: 'ordering/done',
     component: () => import('@/views/ordering/DoneView.vue'),
+    meta: { requiresAuth: true },
   },
   {
     path: '/ordering/done/:orderId(\\d+)',
     name: 'ordering/done',
     component: () => import('@/views/ordering/DoneView.vue'),
+    meta: { requiresAuth: true },
     props: (route) => ({
       orderId: Number(route.params.orderId),
     }),

--- a/samples/web-csr/dressca-frontend/consumer/src/shared/authentication/authentication-guard.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/shared/authentication/authentication-guard.ts
@@ -6,15 +6,6 @@ export const authenticationGuard = (router: Router) => {
   router.beforeEach((to, from) => {
     const authenticationStore = useAuthenticationStore();
     const routingStore = useRoutingStore();
-    const ignoreAuthPaths: (RouteRecordName | null | undefined)[] = [
-      'authentication/login',
-      'catalog',
-      'basket',
-      'error',
-    ];
-    if (ignoreAuthPaths.includes(to.name)) {
-      return true;
-    }
 
     const orderingPaths: (RouteRecordName | null | undefined)[] = [
       'ordering/checkout',
@@ -24,12 +15,12 @@ export const authenticationGuard = (router: Router) => {
       return { name: 'catalog' };
     }
 
-    if (authenticationStore.isAuthenticated) {
-      return true;
+    if (to.meta.requiresAuth && !authenticationStore.isAuthenticated) {
+      const redirectFromPath: string = to.name?.toString() ?? '';
+      routingStore.setRedirectFrom(redirectFromPath);
+      return { name: 'authentication/login' };
     }
 
-    const redirectFromPath: string = to.name?.toString() ?? '';
-    routingStore.setRedirectFrom(redirectFromPath);
-    return { name: 'authentication/login' };
+    return true;
   });
 };


### PR DESCRIPTION
## この Pull request で実施したこと

authentication-guardのパス指定方法をvue-router公式の実装に沿うよう修正しました。実装は以下を参照しました。
- https://router.vuejs.org/guide/advanced/meta.html#Route-Meta-Fields

### consumer（サンプルアプリケーション）
- vue-routerのルーティング定義のmeta属性に認証チェックが必要かどうかの真理値requiresAuthプロパティを追加
- authentication-guardをrequiresAuthを利用して認証チェックが必要かどうか確かめる実装に変更

### admin（管理者用サンプルアプリケーション）
- vue-routerのルーティング定義のmeta属性に認証チェックが必要かどうかの真理値requiresAuthプロパティを追加
- authentication-guardをrequiresAuthを利用して認証チェックが必要かどうか確かめる実装に変更

## この Pull request では実施していないこと

同時並行で対応した、不要なルーティング定義の削除は本PRでは行っていません。
以下のPRを先にレビュいただきたいです。
- #2186 

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #2134 