### PR TITLE
VSCode用のtextlint拡張機能を変更する

### DIFF
--- a/documents/README.md
+++ b/documents/README.md
@@ -383,7 +383,7 @@ Visual Studio Code の [ファイル] メニューから [ワークスペース�
 - [Draw.io integration](https://marketplace.visualstudio.com/items?itemName=hediet.vscode-drawio)
 - [Markdown All in One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one)
 - [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
-- [vscode-textlint](https://marketplace.visualstudio.com/items?itemName=taichi.vscode-textlint)
+- [vscode-textlint](https://marketplace.visualstudio.com/items?itemName=3w36zj6.textlint)
 
 ![拡張機能メニュー](readme-images/recommend-vscode-extensions.png)
 

--- a/documents/README.md
+++ b/documents/README.md
@@ -197,7 +197,7 @@ CSpell の拡張機能をインストールしていると、 [問題] ウィン
 
 #### textlint
 
-vscode-textlint の拡張機能をインストールしていると、 [問題] ウィンドウに校正に関するコメントが出ます。
+textlint（VS Code 拡張機能）の拡張機能をインストールしていると、 [問題] ウィンドウに校正に関するコメントが出ます。
 この拡張機能は、技術ドキュメントを書く際の冗長な表現を排除したり、表記ゆれの検出したりする自動校正ツールです。
 多くの場合、文章の見直しによってエラーを回避できます。
 必ず対応するようにしてください。
@@ -383,7 +383,7 @@ Visual Studio Code の [ファイル] メニューから [ワークスペース�
 - [Draw.io integration](https://marketplace.visualstudio.com/items?itemName=hediet.vscode-drawio)
 - [Markdown All in One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one)
 - [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
-- [vscode-textlint](https://marketplace.visualstudio.com/items?itemName=3w36zj6.textlint)
+- [textlint（VS Code 拡張機能）](https://marketplace.visualstudio.com/items?itemName=3w36zj6.textlint)
 
 ![拡張機能メニュー](readme-images/recommend-vscode-extensions.png)
 

--- a/maia.code-workspace
+++ b/maia.code-workspace
@@ -17,7 +17,7 @@
 			"yzhang.markdown-all-in-one",
 			"davidanson.vscode-markdownlint",
 			"shuworks.vscode-table-formatter",
-			"taichi.vscode-textlint"
+			"3w36zj6.textlint"
 		]
     }
 }


### PR DESCRIPTION
Fixes #2197

## この Pull request で実施したこと

拡張機能のIDを修正しました。

- Change the extension ID in `maia.code-workspace` from `taichi.vscode-textlint` to `3w36zj6.textlint`.
- Update the extension ID in `documents/README.md` from `taichi.vscode-textlint` to `3w36zj6.textlint`.

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AlesInfiny/maia/pull/2204?shareId=5a1866ad-cfa0-49ca-b3d4-d55cfe52c7a9).