### PR TITLE
Dressca サンプルアプリのmockの買い物かごアイテム削除処理を修正

### DIFF
--- a/samples/web-csr/dressca-frontend/consumer/mock/handlers/baskets-handler.ts
+++ b/samples/web-csr/dressca-frontend/consumer/mock/handlers/baskets-handler.ts
@@ -85,7 +85,12 @@ export const basketsHandlers = [
       return response;
     },
   ),
-  http.delete('/api/basket-items/:catalogItemId', async () => {
+  http.delete('/api/basket-items/:catalogItemId', async ({ params }) => {
+    const { catalogItemId } = params;
+    basket.basketItems = basket.basketItems?.filter(
+      (item) => item.catalogItemId !== Number(catalogItemId),
+    );
+    calcBasketAccount();
     return new HttpResponse(null, { status: HttpStatusCode.NoContent });
   }),
 ];


### PR DESCRIPTION
## この Pull request で実施したこと

Dressca の Consumer アプリの mock で買い物かごからアイテムを削除する際の処理が抜けていたため、
買い物かごの削除処理と合計金額の再計算を行うよう、修正しました。

## この Pull request では実施していないこと

なし。

## Issues や Discussions 、関連する Web サイトなどへのリンク
mswの使い方
- https://mswjs.io/docs/api/http/#httpdelete

以前のmswのcounsumer導入
- #2086