### PR TITLE
アイテム編集画面とアイテム追加画面の単価のバリデーションが想定通り動作しない問題に対処

### DIFF
--- a/samples/web-csr/dressca-frontend/admin/src/validation/validation-items.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/validation/validation-items.ts
@@ -23,7 +23,7 @@ export const catalogItemSchema: TypedSchema = toTypedSchema(
     price: yup
       .string()
       .required('単価は必須です。')
-      .matches(/^[1-9]\d*$/, '半角数字で入力してください'),
+      .matches(/^[1-9]\d*$/, '1以上の整数を半角数字で入力してください'),
     productCode: yup
       .string()
       .required('商品コードは必須です。')

--- a/samples/web-csr/dressca-frontend/admin/src/validation/validation-items.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/validation/validation-items.ts
@@ -21,11 +21,9 @@ export const catalogItemSchema: TypedSchema = toTypedSchema(
       .required('説明は必須です。')
       .max(1024, '1024文字以下で入力してください。'),
     price: yup
-      .number()
+      .string()
       .required('単価は必須です。')
-      .typeError('数値で入力してください。')
-      .integer('整数で入力してください。')
-      .positive('正の数で入力してください。'),
+      .matches(/^[1-9]\d*$/, '半角数字で入力してください'),
     productCode: yup
       .string()
       .required('商品コードは必須です。')

--- a/samples/web-csr/dressca-frontend/admin/src/views/catalog/ItemsAddView.vue
+++ b/samples/web-csr/dressca-frontend/admin/src/views/catalog/ItemsAddView.vue
@@ -29,7 +29,7 @@ const { errors, values, meta, defineField } = useForm({
   initialValues: {
     itemName: 'テスト用アイテム',
     itemDescription: 'テスト用アイテムです。',
-    price: 1980,
+    price: '1980',
     productCode: 'T001',
   },
 });
@@ -168,7 +168,7 @@ onMounted(async () => {
         <label for="unit-price" class="mb-2 block font-bold">単価</label>
         <input
           id="unit-price"
-          v-model.number="price"
+          v-model="price"
           type="text"
           name="unit-price"
           class="w-full border border-gray-300 px-4 py-2"

--- a/samples/web-csr/dressca-frontend/admin/src/views/catalog/ItemsEditView.vue
+++ b/samples/web-csr/dressca-frontend/admin/src/views/catalog/ItemsEditView.vue
@@ -44,7 +44,7 @@ interface ItemState {
   id: number;
   name: string;
   description: string;
-  price: number;
+  price: string;
   productCode: string;
   categoryId: number;
   brandId: number;
@@ -72,7 +72,7 @@ const editingItemState = ref<ItemState>({
   id: 0,
   name: '',
   description: '',
-  price: 0,
+  price: '',
   productCode: '',
   categoryId: 0,
   brandId: 0,
@@ -87,7 +87,7 @@ const currentItemState = ref<ItemState>({
   id: 0,
   name: '',
   description: '',
-  price: 0,
+  price: '',
   productCode: '',
   categoryId: 0,
   brandId: 0,
@@ -157,7 +157,7 @@ const setCurrentItemState = (item: GetCatalogItemResponse) => {
   currentItemState.value.id = item.id;
   currentItemState.value.name = item.name;
   currentItemState.value.description = item.description;
-  currentItemState.value.price = item.price;
+  currentItemState.value.price = item.price.toString();
   currentItemState.value.productCode = item.productCode;
   currentItemState.value.categoryId = item.catalogCategoryId;
   currentItemState.value.brandId = item.catalogBrandId;
@@ -507,7 +507,7 @@ const updateItemAsync = async () => {
             <label for="unit-price" class="mb-2 block font-bold">単価</label>
             <input
               id="unit-price"
-              v-model.number="price"
+              v-model="price"
               name="unit-price"
               class="w-full border border-gray-300 px-4 py-2"
             />


### PR DESCRIPTION
## この Pull request で実施したこと

特定の入力パターンにおいて、入力フォームの単価のバリデーションが想定通り動作しない問題に対処しました。

### 変更内容
- yupのバリデーション用のスキーマの単価フィールドについて、数字型から文字列型で受け取って正規表現で半角数字かをチェックするように修正しました。
- これに伴い、編集画面と追加画面の単価フィールドを全体的にnumber型からstring型に変更しました。

### 確認した内容
- アイテム編集画面とアイテム追加画面について、#2234に記載の想定外のケースにおいて、
「半角数字で入力してください」のエラーメッセージが出力されることと、
ボタンが非活性になっていることを確認しました。

## この Pull request では実施していないこと
- 入力中の全角数字を半角数字に変換する機能や、カンマ区切り表示する機能は実装していません。

## Issues や Discussions 、関連する Web サイトなどへのリンク

- なし