### PR TITLE
(admin)通知トーストコンポーネントの内部でストアに依存しないつくりにする

### DIFF
--- a/samples/web-csr/dressca-frontend/admin/src/App.vue
+++ b/samples/web-csr/dressca-frontend/admin/src/App.vue
@@ -6,11 +6,20 @@ import { Bars3Icon } from '@heroicons/vue/24/solid';
 import { logoutAsync } from '@/services/authentication/authentication-service';
 import { useRouter } from 'vue-router';
 import { ref } from 'vue';
+import { useNotificationStore } from '@/stores/notification/notification';
 
 const router = useRouter();
 const authenticationStore = useAuthenticationStore();
 const { authenticationState, userName, userRoles } =
   storeToRefs(authenticationStore);
+
+const notificationStore = useNotificationStore();
+const { message, timeout } = storeToRefs(notificationStore);
+
+/**
+ * トーストの開閉状態です。
+ */
+const showToast = ref(false);
 
 /**
  * ログインメニューの開閉状態です。
@@ -28,7 +37,11 @@ const logout = async () => {
 </script>
 <template>
   <div class="z-2">
-    <NotificationToast />
+    <NotificationToast
+      v-model:show="showToast"
+      v-model:message="message"
+      v-model:timeout="timeout"
+    />
   </div>
   <nav class="bg-gray-800">
     <div class="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8">

--- a/samples/web-csr/dressca-frontend/admin/src/App.vue
+++ b/samples/web-csr/dressca-frontend/admin/src/App.vue
@@ -36,7 +36,7 @@ const logout = async () => {
 };
 </script>
 <template>
-  <div class="z-2">
+  <div class="z-20 fixed">
     <NotificationToast
       v-model:show="showToast"
       v-model:message="message"

--- a/samples/web-csr/dressca-frontend/admin/src/components/NotificationToast.vue
+++ b/samples/web-csr/dressca-frontend/admin/src/components/NotificationToast.vue
@@ -1,28 +1,34 @@
 <script setup lang="ts">
-import { storeToRefs } from 'pinia';
-import { useNotificationStore } from '@/stores/notification/notification';
 import { ExclamationCircleIcon, XMarkIcon } from '@heroicons/vue/24/outline';
-import { ref, watch } from 'vue';
+import { watch } from 'vue';
 
 /**
  * ユーザーにメッセージを通知するトーストです。
  */
-
-const state = ref({
-  show: false,
+const show = defineModel('show', {
+  type: Boolean,
+  required: true,
+  default: false,
+});
+const message = defineModel('message', {
+  type: String,
+  required: true,
+  default: '',
+});
+const timeout = defineModel('timeout', {
+  type: Number,
+  required: true,
+  default: 5000,
 });
 
-const notificationStore = useNotificationStore();
-const { message, timeout } = storeToRefs(notificationStore);
-
 const close = () => {
-  state.value.show = false;
-  notificationStore.clearMessage();
+  show.value = false;
+  message.value = '';
 };
 
 watch(message, (newMessage) => {
   if (newMessage !== '') {
-    state.value.show = true;
+    show.value = true;
     setTimeout(() => {
       close();
     }, timeout.value);
@@ -38,7 +44,7 @@ watch(message, (newMessage) => {
     leave-active-class="transition duration-300"
   >
     <div
-      v-if="state.show"
+      v-if="show"
       class="max-w-m fixed inset-x-0 mx-auto mt-2 inline-flex w-5/6 items-center rounded-lg bg-red-500 p-4 text-gray-500 shadow"
     >
       <div


### PR DESCRIPTION
## この Pull request で実施したこと
通知トーストコンポーネントの内部でストアに依存しないつくりに変更し、トーストからストアからのimportがなくなるようにしました。
一方で、トースト自体はApp.vueに配置して各コンポーネントから共通部品として触りたいので、ストアとサービスで集中管理したままにしています。

- 必要なプロパティをpropsとして受け取るつくりに変更しました。
- App.vueでpropsとして引き渡す値をstoreで管理するようにしました。
- 子コンポーネント側でpropsを編集する（双方向バインディングする）際に利用できる新機能（defineModel）がvue@3.4で導入されていたので、こちらを利用した実装にしました。

### その他
作業過程で1件CSSに軽微な不具合を発見したので、修正しています。
- https://github.com/AlesInfiny/maia/issues/2266

## この Pull request では実施していないこと

consumerについては並行してカスタムエラーハンドラー周りの修正を入れているので、
独立して作業するためにこちらが終わってから別途PRを作成予定です。

## Issues や Discussions 、関連する Web サイトなどへのリンク
- `defineModel() `についての説明は下記の通りです。Vue3.4以降、これまでemitを使った実装が必要だったものをより簡素に実装できるようになりました。
    - https://ja.vuejs.org/guide/components/v-model#component-v-model