### PR TITLE
アイテム編集画面のパスパラメーターのitemIdの定義を数値のみに変更

### DIFF
--- a/samples/web-csr/dressca-frontend/admin/src/router/catalog/catalog.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/router/catalog/catalog.ts
@@ -11,7 +11,7 @@ export const catalogRoutes: RouteRecordRaw[] = [
     meta: { requiresAuth: true },
   },
   {
-    path: '/catalog/items/edit/:itemId',
+    path: '/catalog/items/edit/:itemId(\\d+)',
     name: 'catalog/items/edit',
     component: () => import('@/views/catalog/ItemsEditView.vue'),
     meta: { requiresAuth: true },


### PR DESCRIPTION
## この Pull request で実施したこと
- アイテム編集画面のパスパラメーターのitemIdの定義を数値のみに変更しました。

### 再査してほしい点
- `http://localhost:6173/catalog/items/edit/ああああ`のようなパスパラメータの型が不正なURLをアドレスバーに直打ちした際の挙動が変わったことを確認ください。
修正前：pathに合致すると判断して編集画面を開こうとするが、その後の処理がコケてエラー画面に遷移
修正後：合致するルートがない旨の警告が出力され、エラー画面には遷移しない

## この Pull request では実施していないこと
本来合致するルートがない場合は404ページが出るほうがよいので、別PRで対処しようと思います。

- https://github.com/AlesInfiny/maia/issues/2274

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし