### PR TITLE
買い物かごの取得にカタログから削除済みアイテムのIDリストを追加

### DIFF
--- a/samples/web-csr/dressca-backend/api-docs/web-consumer/api-specification.json
+++ b/samples/web-csr/dressca-backend/api-docs/web-consumer/api-specification.json
@@ -602,6 +602,13 @@
           },
           "buyerId": {
             "type": "string"
+          },
+          "deletedItemIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         },
         "required": [

--- a/samples/web-csr/dressca-backend/application-core/src/main/java/com/dressca/applicationcore/applicationservice/BasketDetail.java
+++ b/samples/web-csr/dressca-backend/application-core/src/main/java/com/dressca/applicationcore/applicationservice/BasketDetail.java
@@ -14,4 +14,5 @@ import lombok.Getter;
 public class BasketDetail {
   Basket basket;
   List<CatalogItem> catalogItems;
+  List<Long> deletedItemIds;
 }

--- a/samples/web-csr/dressca-backend/application-core/src/main/java/com/dressca/applicationcore/applicationservice/ShoppingApplicationService.java
+++ b/samples/web-csr/dressca-backend/application-core/src/main/java/com/dressca/applicationcore/applicationservice/ShoppingApplicationService.java
@@ -129,8 +129,12 @@ public class ShoppingApplicationService {
     List<Long> catalogItemIds = basket.getItems().stream()
         .map(basketItem -> basketItem.getCatalogItemId())
         .collect(Collectors.toList());
-    List<CatalogItem> catalogItems = this.catalogRepository.findByCatalogItemIdIn(catalogItemIds);
-    return new BasketDetail(basket, catalogItems);
+    List<CatalogItem> catalogItems = this.catalogRepository.findByCatalogItemIdInIncludingDeleted(catalogItemIds);
+    List<Long> deletedItemIds = catalogItems.stream()
+        .filter(item -> item.isDeleted())
+        .map(item -> item.getId())
+        .collect(Collectors.toList());
+    return new BasketDetail(basket, catalogItems, deletedItemIds);
   }
 
   /**

--- a/samples/web-csr/dressca-backend/application-core/src/main/java/com/dressca/applicationcore/catalog/CatalogRepository.java
+++ b/samples/web-csr/dressca-backend/application-core/src/main/java/com/dressca/applicationcore/catalog/CatalogRepository.java
@@ -37,8 +37,7 @@ public interface CatalogRepository {
   List<CatalogItem> findByCatalogItemIdIn(List<Long> catalogItemIds);
 
   /**
-   * カタログアイテム ID のリストに一致するカタログのリストを取得します。
-   * その際、削除済みフラグは考慮しません。
+   * 削除済みのカタログアイテムを含めて、カタログアイテム ID のリストに一致するカタログのリストを取得します。
    * 
    * @param catalogItemIds カタログアイテム ID 。
    * @return 条件に一致するカタログのリスト。存在しない場合、空のリスト。

--- a/samples/web-csr/dressca-backend/application-core/src/main/java/com/dressca/applicationcore/catalog/CatalogRepository.java
+++ b/samples/web-csr/dressca-backend/application-core/src/main/java/com/dressca/applicationcore/catalog/CatalogRepository.java
@@ -37,6 +37,15 @@ public interface CatalogRepository {
   List<CatalogItem> findByCatalogItemIdIn(List<Long> catalogItemIds);
 
   /**
+   * カタログアイテム ID のリストに一致するカタログのリストを取得します。
+   * その際、削除済みフラグは考慮しません。
+   * 
+   * @param catalogItemIds カタログアイテム ID 。
+   * @return 条件に一致するカタログのリスト。存在しない場合、空のリスト。
+   */
+  List<CatalogItem> findByCatalogItemIdInIncludingDeleted(List<Long> catalogItemIds);
+
+  /**
    * ブランド ID とカテゴリ ID に一致するカタログの件数を取得します。
    * 
    * @param brandId    ブランド ID 。

--- a/samples/web-csr/dressca-backend/application-core/src/test/java/com/dressca/applicationcore/applicationservice/ShoppingApplicationServiceTest.java
+++ b/samples/web-csr/dressca-backend/application-core/src/test/java/com/dressca/applicationcore/applicationservice/ShoppingApplicationServiceTest.java
@@ -291,7 +291,7 @@ public class ShoppingApplicationServiceTest {
         new CatalogItem(1L, "name1", "desc1", BigDecimal.valueOf(1000), "code1", 1L, 1L, false),
         new CatalogItem(2L, "name2", "desc2", BigDecimal.valueOf(2000), "code2", 2L, 2L, false));
     List<Long> catalogItemIds = List.of(1L, 2L);
-    when(this.catalogRepository.findByCatalogItemIdIn(catalogItemIds)).thenReturn(items);
+    when(this.catalogRepository.findByCatalogItemIdInIncludingDeleted(catalogItemIds)).thenReturn(items);
 
     // テストメソッドの実行
     BasketDetail actual = service.getBasketDetail(dummyBuyerId);
@@ -299,7 +299,7 @@ public class ShoppingApplicationServiceTest {
     assertThat(actual.catalogItems.get(0).getId()).isEqualTo(1L);
     assertThat(actual.catalogItems.get(1).getId()).isEqualTo(2L);
     // モックが想定通り呼び出されていることの確認
-    verify(this.catalogRepository, times(1)).findByCatalogItemIdIn(catalogItemIds);
+    verify(this.catalogRepository, times(1)).findByCatalogItemIdInIncludingDeleted(catalogItemIds);
   }
 
   @ParameterizedTest
@@ -313,7 +313,7 @@ public class ShoppingApplicationServiceTest {
       assertThat(e.getMessage()).startsWith("buyerIdがnullまたは空文字");
     }
     // モックが想定通り呼び出されていることの確認
-    verify(this.catalogRepository, times(0)).findByCatalogItemIdIn(any());
+    verify(this.catalogRepository, times(0)).findByCatalogItemIdInIncludingDeleted(any());
   }
 
   @Test

--- a/samples/web-csr/dressca-backend/infrastructure/src/main/java/com/dressca/infrastructure/repository/mybatis/MybatisCatalogRepository.java
+++ b/samples/web-csr/dressca-backend/infrastructure/src/main/java/com/dressca/infrastructure/repository/mybatis/MybatisCatalogRepository.java
@@ -44,6 +44,11 @@ public class MybatisCatalogRepository implements CatalogRepository {
   }
 
   @Override
+  public List<CatalogItem> findByCatalogItemIdInIncludingDeleted(List<Long> catalogItemIds) {
+    return mapper.findByCatalogItemIdInIncludingDeleted(catalogItemIds);
+  }
+
+  @Override
   public int countByBrandIdAndCategoryId(long brandId, long categoryId) {
     return mapper.countByBrandIdAndCategoryId(brandId, categoryId);
   }

--- a/samples/web-csr/dressca-backend/infrastructure/src/main/java/com/dressca/infrastructure/repository/mybatis/mapper/JoinedCatalogItemMapper.java
+++ b/samples/web-csr/dressca-backend/infrastructure/src/main/java/com/dressca/infrastructure/repository/mybatis/mapper/JoinedCatalogItemMapper.java
@@ -18,6 +18,8 @@ public interface JoinedCatalogItemMapper {
 
   List<CatalogItem> findByCatalogItemIdIn(@Param("catalogItemIds") List<Long> catalogItemIds);
 
+  List<CatalogItem> findByCatalogItemIdInIncludingDeleted(@Param("catalogItemIds") List<Long> catalogItemIds);
+
   int countByBrandIdAndCategoryId(@Param("brandId") long brandId,
       @Param("categoryId") long categoryId);
 

--- a/samples/web-csr/dressca-backend/infrastructure/src/main/java/com/dressca/infrastructure/repository/mybatis/mapper/JoinedCatalogItemMapper.xml
+++ b/samples/web-csr/dressca-backend/infrastructure/src/main/java/com/dressca/infrastructure/repository/mybatis/mapper/JoinedCatalogItemMapper.xml
@@ -24,6 +24,7 @@
       CATALOG_ITEMS.CATALOG_CATEGORY_ID,
       CATALOG_ITEMS.CATALOG_BRAND_ID,
       CATALOG_ITEMS.ROW_VERSION,
+      CATALOG_ITEMS.IS_DELETED,
       ASSETS.ID,
       ASSETS.CATALOG_ITEM_ID,
       ASSETS.ASSET_CODE
@@ -42,6 +43,7 @@
     <result property="catalogCategoryId" column="CATALOG_CATEGORY_ID"/>
     <result property="catalogBrandId" column="CATALOG_BRAND_ID"/>
     <result property="rowVersion" column="ROW_VERSION"/>
+    <result property="isDeleted" column="IS_DELETED"/>
     <collection property="assets" ofType="com.dressca.applicationcore.catalog.CatalogItemAsset" resultMap="assetsResultMap"/>
   </resultMap>
 
@@ -81,6 +83,16 @@
         #{catalogItemId}
       </foreach>
       AND CATALOG_ITEMS.IS_DELETED = false
+    </if>
+  </select>
+
+  <select id="findByCatalogItemIdInIncludingDeleted" resultMap="catalogItemsIncludeAssetResultMap" parameterType="List">
+    <include refid="selectCatalogItemsIncludeAsset"/>
+    <if test="catalogItemIds.size != 0">
+      WHERE CATALOG_ITEMS.ID IN 
+      <foreach item="catalogItemId" collection="catalogItemIds" open="(" separator="," close=")">
+        #{catalogItemId}
+      </foreach>
     </if>
   </select>
 

--- a/samples/web-csr/dressca-backend/web-consumer/src/main/java/com/dressca/web/consumer/controller/BasketItemController.java
+++ b/samples/web-csr/dressca-backend/web-consumer/src/main/java/com/dressca/web/consumer/controller/BasketItemController.java
@@ -77,6 +77,8 @@ public class BasketItemController {
     for (BasketItemResponse item : basketDto.getBasketItems()) {
       item.setCatalogItem(this.getCatalogItemResponse(item.getCatalogItemId(), catalogItems));
     }
+    List<Long> deletedItemIds = basketItemsForUser.getDeletedItemIds();
+    basketDto.setDeletedItemIds(deletedItemIds);
     return ResponseEntity.ok().body(basketDto);
   }
 

--- a/samples/web-csr/dressca-backend/web-consumer/src/main/java/com/dressca/web/consumer/controller/dto/baskets/BasketResponse.java
+++ b/samples/web-csr/dressca-backend/web-consumer/src/main/java/com/dressca/web/consumer/controller/dto/baskets/BasketResponse.java
@@ -18,4 +18,5 @@ public class BasketResponse {
   private String buyerId;
   private AccountResponse account;
   private List<BasketItemResponse> basketItems;
+  private List<Long> deletedItemIds;
 }

--- a/samples/web-csr/dressca-backend/web-consumer/src/main/java/com/dressca/web/consumer/mapper/BasketMapper.java
+++ b/samples/web-csr/dressca-backend/web-consumer/src/main/java/com/dressca/web/consumer/mapper/BasketMapper.java
@@ -36,6 +36,6 @@ public class BasketMapper {
         .map(BasketItemMapper::convert)
         .collect(Collectors.toList());
 
-    return new BasketResponse(basket.getBuyerId(), accountDto, basketItems);
+    return new BasketResponse(basket.getBuyerId(), accountDto, basketItems, null);
   }
 }

--- a/samples/web-csr/dressca-backend/web-consumer/src/main/java/com/dressca/web/consumer/mapper/BasketMapper.java
+++ b/samples/web-csr/dressca-backend/web-consumer/src/main/java/com/dressca/web/consumer/mapper/BasketMapper.java
@@ -1,5 +1,6 @@
 package com.dressca.web.consumer.mapper;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import com.dressca.applicationcore.accounting.Account;
@@ -36,6 +37,6 @@ public class BasketMapper {
         .map(BasketItemMapper::convert)
         .collect(Collectors.toList());
 
-    return new BasketResponse(basket.getBuyerId(), accountDto, basketItems, null);
+    return new BasketResponse(basket.getBuyerId(), accountDto, basketItems, Collections.emptyList());
   }
 }


### PR DESCRIPTION
## この Pull request で実施したこと

- 買い物かごの取得APIにカタログから削除済みアイテムのIDリストを追加しました。
``` json
{
 "購入者ID": "hogehoge",
 "会計情報": {
 },
 "カートの中身": [
   {
     }
 ],
 "削除アイテムのID一覧": [4, 5, 6]
 }
```
- 買い物かごを取得する際に、削除済みアイテムも併せて取得するように変更しました。

## この Pull request では実施していないこと

カタログから削除済みのアイテムを正常に買い物かごから削除する機能は下記Issueで追加します。
- #2239 
## Issues や Discussions 、関連する Web サイトなどへのリンク

- #2238 
- #2100