### PR TITLE
DresscaにおけるmockのESLintの警告に対応

### DIFF
--- a/samples/web-csr/dressca-frontend/consumer/mock/handlers/baskets-handler.ts
+++ b/samples/web-csr/dressca-frontend/consumer/mock/handlers/baskets-handler.ts
@@ -10,16 +10,20 @@ function calcBasketAccount() {
   if (!basket || !basket.account) {
     return;
   }
+  const updatedBasketItems =
+    basket.basketItems?.map((item) => {
+      const subTotal = item.unitPrice * item.quantity;
+      return {
+        ...item,
+        subTotal,
+      };
+    }) || [];
   // undefined になる場合は 0 を代入
-  const totalItemsPrice = basket.basketItems?.length
-    ? basket.basketItems
-        .map((item) => {
-          // eslint-disable-next-line no-param-reassign
-          item.subTotal = item.unitPrice * item.quantity;
-          return item.subTotal;
-        })
-        .reduce((total, subTotal) => total + subTotal, 0)
-    : 0;
+  const totalItemsPrice = updatedBasketItems.reduce(
+    (total, item) => total + item.subTotal,
+    0,
+  );
+  basket.basketItems = updatedBasketItems;
   basket.account.consumptionTaxRate = 0.1;
   basket.account.totalItemsPrice = totalItemsPrice;
   const deliveryCharge = totalItemsPrice >= 5000 ? 0 : 500;


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

Dresscaのmockの以下箇所で、map メソッドの中で引数に直接値を変更する処理に警告が出ていたため対応しました。

``` ts
  const totalItemsPrice = basket.basketItems?.length
    ? basket.basketItems
        .map((item) => {
          // eslint-disable-next-line no-param-reassign
          item.subTotal = item.unitPrice * item.quantity;
          return item.subTotal;
        })
        .reduce((total, subTotal) => total + subTotal, 0)
    : 0;
```

## この Pull request では実施していないこと

- 特になし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #2109 

### 関連リンク
- https://www.reddit.com/r/learnjavascript/comments/y9s4b2/why_eslint_throws_assignment_to_property_of/
- https://stackoverflow.com/questions/62443942/assignment-to-property-of-function-parameter-no-param-reassign

<!-- I want to review in Japanese. -->