### PR TITLE
[Dressca-Consumer]買い物かご画面に Vitest で API コールをモックした自動テストを実装する

### DIFF
--- a/samples/web-csr/dressca-frontend/consumer/package.json
+++ b/samples/web-csr/dressca-frontend/consumer/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.18.4",
+    "@pinia/testing": "^1.0.0",
     "@rushstack/eslint-patch": "^1.11.0",
     "@tsconfig/node20": "^20.1.5",
     "@types/jsdom": "^21.1.7",

--- a/samples/web-csr/dressca-frontend/consumer/src/shared/error-handler/custom-error.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/shared/error-handler/custom-error.ts
@@ -43,7 +43,7 @@ export class ServerError extends HttpError {
   }
 }
 
-interface ProblemDetails {
+export interface ProblemDetails {
   detail: string;
   exceptionId: string;
   exceptionValues: string[];

--- a/samples/web-csr/dressca-frontend/consumer/src/views/__tests__/basket/BasketView.spec.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/__tests__/basket/BasketView.spec.ts
@@ -161,7 +161,7 @@ describe('買い物かごのアイテムを表示する_アイテムが0件', ()
     // Act
     // Assert
     const button = wrapper.findAll('button')[1];
-    expect(button).toBeFalsy();
+    expect(button.exists()).toBe(false);
   });
 });
 
@@ -179,7 +179,7 @@ describe('買い物かごのアイテムを表示する_サーバーエラー', 
       title: expectTitle,
     });
     const error = createAxiosError(problem);
-    getBasketItemsMock.mockRejectedValue(new ServerError('any message', error));
+    getBasketItemsMock.mockRejectedValue(new ServerError('', error));
     const expectMessage = 'サーバーエラーが発生しました。';
     await getWrapper();
     const notificationStore = useNotificationStore();

--- a/samples/web-csr/dressca-frontend/consumer/src/views/__tests__/basket/BasketView.spec.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/__tests__/basket/BasketView.spec.ts
@@ -7,11 +7,9 @@ import { createCustomErrorHandler } from '@/shared/error-handler/custom-error-ha
 import BasketView from '@/views/basket/BasketView.vue';
 import type { BasketResponse } from '@/generated/api-client';
 import { ServerError } from '@/shared/error-handler/custom-error';
-import { type ProblemDetails } from '@/shared/error-handler/custom-error';
-// TODO Maia・Maris 間でProblemDetails が共通化できたら、@/generated/api-client/model から import します。
 import { useNotificationStore } from '@/stores/notification/notification';
-import { AxiosError, AxiosHeaders } from 'axios';
 import BasketItem from '@/components/basket/BasketItem.vue';
+import { createAxiosError, createProblemDetails } from '../helpers';
 
 function createBasketResponse(): BasketResponse {
   return {
@@ -66,49 +64,6 @@ function createEmptyBasketResponse(): BasketResponse {
   };
 }
 
-function createAxiosError(problemDetails: ProblemDetails): AxiosError {
-  const error = new AxiosError('', '', undefined, null, {
-    status: problemDetails.status,
-    statusText: '',
-    headers: {},
-    config: {
-      headers: new AxiosHeaders({
-        'Content-Type': 'application/json',
-      }),
-    },
-    data: {
-      detail: problemDetails.detail,
-      exceptionId: problemDetails.exceptionId,
-      exceptionValues: problemDetails.exceptionValues,
-      instance: problemDetails.instance,
-      status: problemDetails.status,
-      title: problemDetails.title,
-      type: problemDetails.type,
-    },
-  });
-  return error;
-}
-
-function createProblemDetails({
-  detail = 'No details available',
-  exceptionId = 'exceptionId',
-  exceptionValues = [],
-  instance = '/api/',
-  status = 500,
-  title = 'Internal Server Error',
-  type = 'about:blank',
-}: Partial<ProblemDetails>): ProblemDetails {
-  return {
-    detail,
-    exceptionId,
-    exceptionValues,
-    instance,
-    status,
-    title,
-    type,
-  };
-}
-
 /**
  *  vi.mock はファイルの先頭に巻き上げられるので、
  * 複数回 vi.mock を宣言すると、最後に定義されたもので上書きされてしまいます。
@@ -153,8 +108,8 @@ describe('買い物かごのアイテムを表示する_アイテムが入って
     const expectCount = createBasketResponse().basketItems?.length!;
     // Act
     await flushPromises();
-    const basketItem = wrapper.findAllComponents(BasketItem);
     // Assert
+    const basketItem = wrapper.findAllComponents(BasketItem);
     expect(wrapper.html()).toContain('クルーネック Tシャツ - ブラック');
     expect(wrapper.html()).toContain('裏起毛 スキニーデニム');
     expect(basketItem).toHaveLength(expectCount);
@@ -163,16 +118,16 @@ describe('買い物かごのアイテムを表示する_アイテムが入って
   it('「買い物を続ける」ボタンが表示されている', () => {
     // Arrange
     // Act
-    const button = wrapper.findAll('button')[0];
     // Assert
+    const button = wrapper.findAll('button')[0];
     expect(button.isVisible()).toBe(true);
   });
 
   it('「レジに進む」ボタンが表示されている', () => {
     // Arrange
     // Act
-    const button = wrapper.findAll('button')[1];
     // Assert
+    const button = wrapper.findAll('button')[1];
     expect(button.isVisible()).toBe(true);
   });
 });
@@ -196,16 +151,16 @@ describe('買い物かごのアイテムを表示する_アイテムが0件', ()
   it('「買い物を続ける」ボタンが表示されている', () => {
     // Arrange
     // Act
-    const button = wrapper.findAll('button')[0];
     // Assert
+    const button = wrapper.findAll('button')[0];
     expect(button.isVisible()).toBe(true);
   });
 
   it('「レジに進む」ボタンが表示されていない', () => {
     // Arrange
     // Act
-    const button = wrapper.findAll('button')[1];
     // Assert
+    const button = wrapper.findAll('button')[1];
     expect(button).toBeFalsy();
   });
 });

--- a/samples/web-csr/dressca-frontend/consumer/src/views/__tests__/basket/BasketView.spec.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/__tests__/basket/BasketView.spec.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeAll, assert } from 'vitest';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { router } from '@/router';
+import { i18n } from '@/locales/i18n';
+import { createTestingPinia } from '@pinia/testing';
+import { createCustomErrorHandler } from '@/shared/error-handler/custom-error-handler';
+import BasketView from '@/views/basket/BasketView.vue';
+import type { BasketResponse } from '@/generated/api-client';
+import { ServerError } from '@/shared/error-handler/custom-error';
+import { type ProblemDetails } from '@/shared/error-handler/custom-error';
+// TODO Maia・Maris 間でProblemDetails が共通化できたら、@/generated/api-client/model から import します。
+import { useNotificationStore } from '@/stores/notification/notification';
+import { AxiosError, AxiosHeaders } from 'axios';
+import BasketItem from '@/components/basket/BasketItem.vue';
+
+function createBasketResponse(): BasketResponse {
+  return {
+    buyerId: 'xxxxxxxxxxxxxxxxxxxxxxxxxx',
+    account: {
+      consumptionTaxRate: 0.1,
+      consumptionTax: 248,
+      deliveryCharge: 500,
+      totalItemsPrice: 1980,
+      totalPrice: 2728,
+    },
+    basketItems: [
+      {
+        catalogItemId: 1,
+        quantity: 1,
+        unitPrice: 1980,
+        catalogItem: {
+          id: 1,
+          name: 'クルーネック Tシャツ - ブラック',
+          productCode: 'C000000001',
+          assetCodes: [],
+        },
+        subTotal: 1980,
+      },
+      {
+        catalogItemId: 2,
+        quantity: 2,
+        unitPrice: 4800,
+        catalogItem: {
+          id: 2,
+          name: '裏起毛 スキニーデニム',
+          productCode: 'C000000002',
+          assetCodes: ['4aed07c4ed5d45a5b97f11acedfbb601'],
+        },
+        subTotal: 9600,
+      },
+    ],
+  };
+}
+
+function createEmptyBasketResponse(): BasketResponse {
+  return {
+    buyerId: 'xxxxxxxxxxxxxxxxxxxxxxxxxx',
+    account: {
+      consumptionTaxRate: 0.1,
+      consumptionTax: 0,
+      deliveryCharge: 500,
+      totalItemsPrice: 0,
+      totalPrice: 0,
+    },
+    basketItems: [],
+  };
+}
+
+function createAxiosError(problemDetails: ProblemDetails): AxiosError {
+  const error = new AxiosError('', '', undefined, null, {
+    status: problemDetails.status,
+    statusText: '',
+    headers: {},
+    config: {
+      headers: new AxiosHeaders({
+        'Content-Type': 'application/json',
+      }),
+    },
+    data: {
+      detail: problemDetails.detail,
+      exceptionId: problemDetails.exceptionId,
+      exceptionValues: problemDetails.exceptionValues,
+      instance: problemDetails.instance,
+      status: problemDetails.status,
+      title: problemDetails.title,
+      type: problemDetails.type,
+    },
+  });
+  return error;
+}
+
+function createProblemDetails({
+  detail = 'No details available',
+  exceptionId = 'exceptionId',
+  exceptionValues = [],
+  instance = '/api/',
+  status = 500,
+  title = 'Internal Server Error',
+  type = 'about:blank',
+}: Partial<ProblemDetails>): ProblemDetails {
+  return {
+    detail,
+    exceptionId,
+    exceptionValues,
+    instance,
+    status,
+    title,
+    type,
+  };
+}
+
+/**
+ *  vi.mock はファイルの先頭に巻き上げられるので、
+ * 複数回 vi.mock を宣言すると、最後に定義されたもので上書きされてしまいます。
+ * モックの振る舞いをテストケースごとに変更したい場合は、
+ *  vi.hoisted を使用します。
+ */
+const { getBasketItemsMock } = vi.hoisted(() => {
+  return {
+    getBasketItemsMock: vi.fn(),
+  };
+});
+
+vi.mock('@/api-client', () => ({
+  basketItemsApi: {
+    getBasketItems: getBasketItemsMock,
+  },
+}));
+
+async function getWrapper() {
+  const pinia = createTestingPinia({
+    createSpy: vi.fn, // 明示的に設定する必要があります。
+    stubActions: false, // 結合テストなので、アクションはモック化しないように設定します。
+  });
+  i18n.global.locale.value = 'ja'; // デフォルトの jsdom 環境では英語（en）に設定されるので、日本語に変更します。
+  const customErrorHandler = createCustomErrorHandler();
+  return mount(BasketView, {
+    global: { plugins: [pinia, router, i18n, customErrorHandler] },
+  });
+}
+
+describe('買い物かごのアイテムを表示する_アイテムが入っている', () => {
+  let wrapper: VueWrapper;
+
+  beforeAll(async (): Promise<void> => {
+    // onMounted のタイミングで API コールを行っているので、wrapper の作成よりも先にモックする必要があります。
+    getBasketItemsMock.mockResolvedValue({ data: createBasketResponse() });
+    wrapper = await getWrapper();
+  });
+
+  it('取得したアイテムの情報が表示される', async () => {
+    // Arrange
+    const expectCount = createBasketResponse().basketItems?.length!;
+    // Act
+    await flushPromises();
+    const basketItem = wrapper.findAllComponents(BasketItem);
+    // Assert
+    expect(wrapper.html()).toContain('クルーネック Tシャツ - ブラック');
+    expect(wrapper.html()).toContain('裏起毛 スキニーデニム');
+    expect(basketItem).toHaveLength(expectCount);
+  });
+
+  it('「買い物を続ける」ボタンが表示されている', () => {
+    // Arrange
+    // Act
+    const button = wrapper.findAll('button')[0];
+    // Assert
+    expect(button.isVisible()).toBe(true);
+  });
+
+  it('「レジに進む」ボタンが表示されている', () => {
+    // Arrange
+    // Act
+    const button = wrapper.findAll('button')[1];
+    // Assert
+    expect(button.isVisible()).toBe(true);
+  });
+});
+
+describe('買い物かごのアイテムを表示する_アイテムが0件', () => {
+  let wrapper: VueWrapper;
+
+  beforeAll(async (): Promise<void> => {
+    getBasketItemsMock.mockResolvedValue({ data: createEmptyBasketResponse() });
+    wrapper = await getWrapper();
+  });
+
+  it('0件を示すメッセージが表示される', async () => {
+    // Arrange
+    // Act
+    await flushPromises();
+    // Assert
+    expect(wrapper.html()).toContain('買い物かごに商品がありません。');
+  });
+
+  it('「買い物を続ける」ボタンが表示されている', () => {
+    // Arrange
+    // Act
+    const button = wrapper.findAll('button')[0];
+    // Assert
+    expect(button.isVisible()).toBe(true);
+  });
+
+  it('「レジに進む」ボタンが表示されていない', () => {
+    // Arrange
+    // Act
+    const button = wrapper.findAll('button')[1];
+    // Assert
+    expect(button).toBeFalsy();
+  });
+});
+
+describe('買い物かごのアイテムを表示する_サーバーエラー', () => {
+  it('サーバーエラー_通知ストアにサーバーエラーを示すメッセージが格納される', async () => {
+    // Arrange
+    const expectDetail = 'expectDetail';
+    const expectExceptionId = 'serverError';
+    const expectStatus = 500;
+    const expectTitle = 'expectTitle';
+    const problem = createProblemDetails({
+      detail: expectDetail,
+      exceptionId: expectExceptionId,
+      status: expectStatus,
+      title: expectTitle,
+    });
+    const error = createAxiosError(problem);
+    getBasketItemsMock.mockRejectedValue(new ServerError('any message', error));
+    const expectMessage = 'サーバーエラーが発生しました。';
+    await getWrapper();
+    const notificationStore = useNotificationStore();
+
+    // Act
+    await flushPromises();
+
+    // Assert
+    assert.equal(notificationStore.message, expectMessage);
+    assert.equal(notificationStore.id, expectExceptionId);
+    assert.equal(notificationStore.title, expectTitle);
+    assert.equal(notificationStore.detail, expectDetail);
+    assert.equal(notificationStore.status, expectStatus);
+  });
+});

--- a/samples/web-csr/dressca-frontend/consumer/src/views/__tests__/basket/BasketView.spec.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/__tests__/basket/BasketView.spec.ts
@@ -160,7 +160,7 @@ describe('買い物かごのアイテムを表示する_アイテムが0件', ()
     // Arrange
     // Act
     // Assert
-    const button = wrapper.findAll('button')[1];
+    const button = wrapper.find('[data-testId="orderButton"]');
     expect(button.exists()).toBe(false);
   });
 });

--- a/samples/web-csr/dressca-frontend/consumer/src/views/__tests__/helpers/index.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/__tests__/helpers/index.ts
@@ -1,0 +1,68 @@
+// TODO Maia・Maris 間でProblemDetails が共通化できたら、@/generated/api-client/model から import します。
+import type { ProblemDetails } from '@/shared/error-handler/custom-error';
+import { AxiosError, AxiosHeaders } from 'axios';
+
+/**
+ * 引数の ProblemDetails オブジェクトの情報を持つ AxiosError を作成します。
+ *
+ * @param {ProblemDetails} problemDetails - API レスポンスから取得した詳細な問題情報。
+ * @returns {AxiosError} 作成した AxiosError 。
+ *
+ */
+export function createAxiosError(problemDetails: ProblemDetails): AxiosError {
+  const error = new AxiosError('', '', undefined, null, {
+    status: problemDetails.status,
+    statusText: '',
+    headers: {},
+    config: {
+      headers: new AxiosHeaders({
+        'Content-Type': 'application/json',
+      }),
+    },
+    data: {
+      detail: problemDetails.detail,
+      exceptionId: problemDetails.exceptionId,
+      exceptionValues: problemDetails.exceptionValues,
+      instance: problemDetails.instance,
+      status: problemDetails.status,
+      title: problemDetails.title,
+      type: problemDetails.type,
+    },
+  });
+  return error;
+}
+
+/**
+ * 引数の情報を持つ、 API のエラーレスポンスの詳細な問題情報（`ProblemDetails`）を作成します。
+ * 引数の各プロパティが指定されていない場合は、デフォルト値を使用します。
+ *
+ * @param {Partial<ProblemDetails>} param - `ProblemDetails`のプロパティの一部を含むオブジェクト。
+ * @param {string} [param.detail='No details available'] - 問題の詳細。
+ * @param {string} [param.exceptionId='exceptionId'] - 例外の ID 。
+ * @param {Array<string>} [param.exceptionValues=[]] - 例外に関連する値の配列。
+ * @param {string} [param.instance='/api/'] - 問題が発生したリソースの URI 。
+ * @param {number} [param.status=500] - HTTP ステータスコード。
+ * @param {string} [param.title='Internal Server Error'] - タイトル。
+ * @param {string} [param.type='about:blank'] - 問題の種類を識別する URI 。
+ * @returns {ProblemDetails} 作成した`ProblemDetails`。
+ *
+ */
+export function createProblemDetails({
+  detail = 'No details available',
+  exceptionId = 'exceptionId',
+  exceptionValues = [],
+  instance = '/api/',
+  status = 500,
+  title = 'Internal Server Error',
+  type = 'about:blank',
+}: Partial<ProblemDetails>): ProblemDetails {
+  return {
+    detail,
+    exceptionId,
+    exceptionValues,
+    instance,
+    status,
+    title,
+    type,
+  };
+}

--- a/samples/web-csr/dressca-frontend/consumer/src/views/basket/BasketView.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/basket/BasketView.vue
@@ -220,6 +220,7 @@ onUnmounted(async () => {
         </button>
         <span v-if="!isEmpty()">
           <button
+            data-testid="orderButton"
             class="w-36 mt-4 mr-4 bg-orange-500 hover:bg-amber-700 text-white font-bold py-2 px-4 rounded"
             type="submit"
             @click="order()"

--- a/samples/web-csr/dressca-frontend/consumer/src/views/basket/BasketView.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/basket/BasketView.vue
@@ -220,7 +220,7 @@ onUnmounted(async () => {
         </button>
         <span v-if="!isEmpty()">
           <button
-            data-testid="orderButton"
+            data-testId="orderButton"
             class="w-36 mt-4 mr-4 bg-orange-500 hover:bg-amber-700 text-white font-bold py-2 px-4 rounded"
             type="submit"
             @click="order()"

--- a/samples/web-csr/dressca-frontend/package-lock.json
+++ b/samples/web-csr/dressca-frontend/package-lock.json
@@ -77,6 +77,7 @@
       },
       "devDependencies": {
         "@openapitools/openapi-generator-cli": "^2.18.4",
+        "@pinia/testing": "^1.0.0",
         "@rushstack/eslint-patch": "^1.11.0",
         "@tsconfig/node20": "^20.1.5",
         "@types/jsdom": "^21.1.7",


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと
- リリースをまたいだため、下記のPRを再作成のうえ、既指摘に対応いたしました。
     - https://github.com/AlesInfiny/maia/pull/1939

- 買い物かご画面に正常系の自動テストを追加しました。
- 買い物かご画面に異常系の自動テストを追加しました。
- ストアの中身を確認するために、ライブラリ @pinia/testingを追加しました。pinia の公式ドキュメントで使用されており、こちらを導入しないとstoreをテストできないので、導入に問題ないと判断しました。admin には導入済みです。
- 型の情報を取得するために、 ProblemDetails を export するようにしました。アプリケーション本体に特に影響はございません。shared 配下のコードのため、公開しても特に問題ないと判断しました。

## この Pull request では実施していないこと
- 買い物かごを取得するユースケースにスコープを限定しています。買い物かごのアイテムの数量更新・削除のユースケースには対応していません。

- 異常系の Toast へのメッセージ出力については、NotificationToast コンポーネントが App.vue に存在するので、買い物かご画面のテストケースのスコープ外とし、ストアにメッセージが正しく格納されたことまでを確認しています。

- ボタンを配列の番号で特定している問題については下記のissueで対応予定です。
    - https://github.com/AlesInfiny/maia/issues/1653

## Issues や Discussions 、関連する Web サイトなどへのリンク
- vi.hoisted の必要性については下記の記事をご覧ください。
>https://dev.classmethod.jp/articles/handling-exception-hoist-in-vitest/

- pinia のテストに関するドキュメント
>https://pinia.vuejs.org/cookbook/testing.html#Unit-testing-components

<!-- I want to review in Japanese. -->