### PR TITLE
GradleプラグインのtoolVersionをdependabotの検知対象に追加

### DIFF
--- a/samples/azure-ad-b2c-sample/auth-backend/build.gradle
+++ b/samples/azure-ad-b2c-sample/auth-backend/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 }
 
 plugins {
-  id 'com.github.spotbugs' version "${spotbugsVersion}" apply false
+  id 'com.github.spotbugs' version "$spotbugsVersion" apply false
 }
 
 subprojects {

--- a/samples/azure-ad-b2c-sample/auth-backend/build.gradle
+++ b/samples/azure-ad-b2c-sample/auth-backend/build.gradle
@@ -41,15 +41,15 @@ subprojects {
   }
 
   jacoco {
-    toolVersion = '0.8.12'
+    toolVersion = "$jacocoToolVersion"
   }
   checkstyle {
-    toolVersion = '10.21.4'
+    toolVersion = "$checkstyleToolVersion"
     configDirectory = rootProject.file('config/checkstyle')
   } 
   spotbugs {
     excludeFilter.set(rootProject.file('config/spotbugs/exclude-filter.xml'))
-    toolVersion = '4.8.6'
+    toolVersion = "$spotbugsToolVersion"
     ignoreFailures = true
   }
 

--- a/samples/azure-ad-b2c-sample/auth-backend/dependencies.gradle
+++ b/samples/azure-ad-b2c-sample/auth-backend/dependencies.gradle
@@ -5,6 +5,11 @@ ext {
     springdocOpenapiGradlePluginVersion = "1.9.0"
     spotbugsVersion = "6.1.7"
 
+    // -- TOOLS
+    jacocoToolVersion = "0.8.12"
+    checkstyleToolVersion = "10.21.4"
+    spotbugsToolVersion = "4.8.6"
+
     // -- DEPENDENCIES
     springdocOpenapiVersion = "2.8.6"
     springCloudAzureVersion = "5.21.0"
@@ -23,6 +28,10 @@ ext {
         spring_security_test : 'org.springframework.security:spring-security-test',
 
         lombok : "org.projectlombok:lombok",
-        slf4j : "org.slf4j:slf4j-simple"
+        slf4j : "org.slf4j:slf4j-simple",
+        
+        jacoco : "org.jacoco:org.jacoco.core:$jacocoToolVersion",
+        checkstyle : "com.puppycrawl.tools:checkstyle:$checkstyleToolVersion",
+        spotbugs : "com.github.spotbugs:spotbugs:$spotbugsToolVersion"
     ]
 }

--- a/samples/web-csr/dressca-backend/build.gradle
+++ b/samples/web-csr/dressca-backend/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 
 plugins {
-  id 'com.github.spotbugs' version "${spotbugsVersion}" apply false
+  id 'com.github.spotbugs' version "$spotbugsVersion" apply false
 }
 
 subprojects {
@@ -36,15 +36,15 @@ subprojects {
   }
 
   jacoco {
-    toolVersion = '0.8.12'
+    toolVersion = "$jacocoToolVersion"
   }
   checkstyle {
-    toolVersion = '10.21.4'
+    toolVersion = "$checkstyleToolVersion"
     configDirectory = rootProject.file('config/checkstyle')
   } 
   spotbugs {
     excludeFilter.set(rootProject.file('config/spotbugs/exclude-filter.xml'))
-    toolVersion = '4.8.6'
+    toolVersion = "$spotbugsToolVersion"
     ignoreFailures = true
   }
 

--- a/samples/web-csr/dressca-backend/dependencies.gradle
+++ b/samples/web-csr/dressca-backend/dependencies.gradle
@@ -5,6 +5,11 @@ ext {
     springdocOpenapiGradlePluginVersion = "1.9.0"
     spotbugsVersion = "6.1.7"
 
+    // -- TOOLS
+    jacocoToolVersion = "0.8.12"
+    checkstyleToolVersion = "10.21.4"
+    spotbugsToolVersion = "4.8.6"
+
     // -- DEPENDENCIES
     springBatchTestVersion = "5.2.2"
     mybatisSpringBootStarterVersion = "3.0.4"
@@ -38,6 +43,10 @@ ext {
         mybatis_generator_core: "org.mybatis.generator:mybatis-generator-core:$mybatisGeneratorVersion",
 
         lombok : "org.projectlombok:lombok",
-        slf4j : "org.slf4j:slf4j-simple"
+        slf4j : "org.slf4j:slf4j-simple",
+
+        jacoco : "org.jacoco:org.jacoco.core:$jacocoToolVersion",
+        checkstyle : "com.puppycrawl.tools:checkstyle:$checkstyleToolVersion",
+        spotbugs : "com.github.spotbugs:spotbugs:$spotbugsToolVersion"
     ]
 }


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

DresscaサンプルとADB2Cサンプルで以下を実施しました。
- `{% root %}/dependencies.gradle`で、pluginで使用するツールを依存関係に追加しました。
- `{% root %}/build.gradle`で、pluginで使用するツールバージョンを変数で管理するように書き換えました。

## この Pull request では実施していないこと

プラグインのツールバージョンをdependabotで検知する方法として、Gradle Version Catalog がありましたが、pluginとtoolのバージョンが同期していないと利用できないため、採用を見送りました。
- https://www.docswell.com/s/nemuki/Z6Y3W7-2024-07-09-140132

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #919 

<!-- I want to review in Japanese. -->