### PR TITLE
命名規則に沿っていない定数の変数名を修正

### DIFF
--- a/samples/web-csr/dressca-backend/application-core/src/main/java/com/dressca/applicationcore/assets/AssetTypes.java
+++ b/samples/web-csr/dressca-backend/application-core/src/main/java/com/dressca/applicationcore/assets/AssetTypes.java
@@ -7,8 +7,8 @@ import org.apache.commons.lang3.StringUtils;
  * アセットタイプを管理するクラスです。
  */
 public class AssetTypes {
-  public static final String png = "png";
-  private static final Set<String> supportedAssetTypes = Set.of(png);
+  public static final String PNG = "png";
+  private static final Set<String> supportedAssetTypes = Set.of(PNG);
 
   /**
    * アセットタイプが対応しているかどうかを判定します。

--- a/samples/web-csr/dressca-backend/web-admin/src/main/java/com/dressca/web/admin/controller/AssetsController.java
+++ b/samples/web-csr/dressca-backend/web-admin/src/main/java/com/dressca/web/admin/controller/AssetsController.java
@@ -79,7 +79,7 @@ public class AssetsController {
    */
   private MediaType getContentType(Asset asset) {
     switch (asset.getAssetType()) {
-      case AssetTypes.png:
+      case AssetTypes.PNG:
         return MediaType.IMAGE_PNG;
       default:
         throw new IllegalArgumentException("指定したアセットのアセットタイプは Content-Type に変換できません。");

--- a/samples/web-csr/dressca-backend/web-consumer/src/main/java/com/dressca/web/consumer/controller/AssetsController.java
+++ b/samples/web-csr/dressca-backend/web-consumer/src/main/java/com/dressca/web/consumer/controller/AssetsController.java
@@ -97,7 +97,7 @@ public class AssetsController {
    */
   private MediaType getContentType(Asset asset) {
     switch (asset.getAssetType()) {
-      case AssetTypes.png:
+      case AssetTypes.PNG:
         return MediaType.IMAGE_PNG;
       default:
         String errorMessage = messages.getMessage(ExceptionIdConstants.E_ASSET_TYPE_NOT_CONVERTED,

--- a/samples/web-csr/dressca-backend/web/src/test/java/com/dressca/web/controller/AssetsController.java
+++ b/samples/web-csr/dressca-backend/web/src/test/java/com/dressca/web/controller/AssetsController.java
@@ -97,7 +97,7 @@ public class AssetsController {
    */
   private MediaType getContentType(Asset asset) {
     switch (asset.getAssetType()) {
-      case AssetTypes.png:
+      case AssetTypes.PNG:
         return MediaType.IMAGE_PNG;
       default:
         String errorMessage = messages.getMessage(ExceptionIdConstants.E_ASSET_TYPE_NOT_CONVERTED,


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

- `application-core/src/main/java/com/dressca/applicationcore/assets/AssetTypes.java` 内の以下の定数が命名規則に沿っていないため、修正しました。
```java
// 修正前
public static final String png = "png";

// 修正後
public static final String PNG = "png";
```
- 上記の定数が使用されている箇所を修正しました。
- 他箇所で修正が必要な定数がないことを確認しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #2304

<!-- I want to review in Japanese. -->