### PR TITLE
[admin]存在しないルートにアクセスした場合にNotFoundページを表示する

### DIFF
--- a/samples/web-csr/dressca-frontend/admin/src/router/error/error.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/router/error/error.ts
@@ -8,7 +8,7 @@ export const errorRoutes: RouteRecordRaw[] = [
     path: '/error',
     name: 'error',
     component: () => import('@/views/error/ErrorView.vue'),
-    meta: { requiresAuth: false },
+    meta: { requiresAuth: true },
   },
   {
     path: '/:pathMatch(.*)*',

--- a/samples/web-csr/dressca-frontend/admin/src/router/error/error.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/router/error/error.ts
@@ -10,4 +10,10 @@ export const errorRoutes: RouteRecordRaw[] = [
     component: () => import('@/views/error/ErrorView.vue'),
     meta: { requiresAuth: false },
   },
+  {
+    path: '/:pathMatch(.*)*',
+    name: 'notFound',
+    component: () => import('@/views/error/NotFoundView.vue'),
+    meta: { requiresAuth: true },
+  },
 ];

--- a/samples/web-csr/dressca-frontend/admin/src/views/error/NotFoundView.vue
+++ b/samples/web-csr/dressca-frontend/admin/src/views/error/NotFoundView.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="bg-white text-gray-800">
+    <div class="flex justify-center">
+      <div class="bg-white p-8">
+        <p class="mb-4 text-2xl font-medium">
+          指定したページが見つかりませんでした。
+        </p>
+        <p class="mb-6 text-lg">
+          アクセスしようとしたページは、削除または移動されたか、現在利用できない状態です。<br />
+          必要な情報が見つからない場合は、管理者にご連絡いただくか、システム内のメニューから再度お試しください。
+        </p>
+        <div class="flex space-x-4 text-lg">
+          <RouterLink
+            to="/"
+            class="text-blue-600 underline hover:text-blue-900"
+          >
+            トップページに戻る
+          </RouterLink>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

- どのルートにもマッチしなかった場合のルートを定義し、Not Found ページを割り当てました。
    - 文言はConsumerと比較して業務アプリを想定したニュアンスの文言に変更しています。
- adminは利用時に認証を要求するシステムのため、Not Found ページについてもmeta情報で認証を必要としました。
    - Not Found ページにシステム管理者や関連部門の連絡先などを掲載するケースで、未認証のユーザーがこれらの情報を閲覧できることが望ましくないと判断しました。
- これに合わせて、同様にErrorページについても認証を必要とするよう変更しました。

## この Pull request では実施していないこと
- adminはメッセージの集中管理が未導入のため、consumerと異なり文言はHTMLにべた書きとしています。

## Issues や Discussions 、関連する Web サイトなどへのリンク
Consumerの下記の対応と同様の内容です。
- https://github.com/AlesInfiny/maia/pull/2391

<!-- I want to review in Japanese. -->