### PR TITLE
Controllerクラスの戻り値においてワイルドカード使用を避けた記述に変更

### DIFF
--- a/samples/web-csr/dressca-backend/web-consumer/src/main/java/com/dressca/web/consumer/controller/AssetsController.java
+++ b/samples/web-csr/dressca-backend/web-consumer/src/main/java/com/dressca/web/consumer/controller/AssetsController.java
@@ -66,7 +66,7 @@ public class AssetsController {
       @ApiResponse(responseCode = "404", description = "アセットコードに対応するアセットがありません。", content = @Content(mediaType = "application/problem+json", schema = @Schema(implementation = ProblemDetail.class)))
   })
   @GetMapping("{assetCode}")
-  public ResponseEntity<?> get(
+  public ResponseEntity<Object> get(
       @Parameter(required = true, description = "アセットコード") @PathVariable("assetCode") String assetCode)
       throws LogicException {
     try {

--- a/samples/web-csr/dressca-backend/web-consumer/src/main/java/com/dressca/web/consumer/controller/BasketItemController.java
+++ b/samples/web-csr/dressca-backend/web-consumer/src/main/java/com/dressca/web/consumer/controller/BasketItemController.java
@@ -102,7 +102,7 @@ public class BasketItemController {
       @ApiResponse(responseCode = "400", description = "リクエストエラー。", content = @Content(mediaType = "application/problem+json", schema = @Schema(implementation = ProblemDetail.class)))
   })
   @PutMapping()
-  public ResponseEntity<?> putBasketItems(@RequestBody List<PutBasketItemsRequest> putBasketItems,
+  public ResponseEntity<Object> putBasketItems(@RequestBody List<PutBasketItemsRequest> putBasketItems,
       HttpServletRequest req) {
     if (putBasketItems.isEmpty()) {
       return ResponseEntity.badRequest().build();
@@ -168,7 +168,7 @@ public class BasketItemController {
       @ApiResponse(responseCode = "500", description = "サーバーエラー。", content = @Content(mediaType = "application/problem+json", schema = @Schema(implementation = ProblemDetail.class)))
   })
   @PostMapping
-  public ResponseEntity<?> postBasketItem(@RequestBody PostBasketItemsRequest postBasketItem,
+  public ResponseEntity<Object> postBasketItem(@RequestBody PostBasketItemsRequest postBasketItem,
       HttpServletRequest req) {
     String buyerId = req.getAttribute("buyerId").toString();
     try {
@@ -212,7 +212,7 @@ public class BasketItemController {
       @ApiResponse(responseCode = "404", description = "買い物かご内に指定したカタログアイテム ID がありません。", content = @Content(mediaType = "application/problem+json", schema = @Schema(implementation = ProblemDetail.class)))
   })
   @DeleteMapping("{catalogItemId}")
-  public ResponseEntity<?> deleteBasketItem(@PathVariable("catalogItemId") long catalogItemId,
+  public ResponseEntity<Object> deleteBasketItem(@PathVariable("catalogItemId") long catalogItemId,
       HttpServletRequest req) {
     String buyerId = req.getAttribute("buyerId").toString();
 

--- a/samples/web-csr/dressca-backend/web-consumer/src/main/java/com/dressca/web/consumer/controller/OrderController.java
+++ b/samples/web-csr/dressca-backend/web-consumer/src/main/java/com/dressca/web/consumer/controller/OrderController.java
@@ -70,7 +70,7 @@ public class OrderController {
       @ApiResponse(responseCode = "404", description = "注文 ID が存在しません。", content = @Content(mediaType = "application/problem+json", schema = @Schema(implementation = ProblemDetail.class)))
   })
   @GetMapping("{orderId}")
-  public ResponseEntity<?> getById(@PathVariable("orderId") long orderId,
+  public ResponseEntity<Object> getById(@PathVariable("orderId") long orderId,
       HttpServletRequest req) {
     String buyerId = req.getAttribute("buyerId").toString();
 
@@ -105,7 +105,7 @@ public class OrderController {
       @ApiResponse(responseCode = "400", description = "リクエストエラー。", content = @Content(mediaType = "application/problem+json", schema = @Schema(implementation = ProblemDetail.class))),
       @ApiResponse(responseCode = "500", description = "サーバーエラー。", content = @Content(mediaType = "application/problem+json", schema = @Schema(implementation = ProblemDetail.class))) })
   @PostMapping
-  public ResponseEntity<?> postOrder(@RequestBody @Valid PostOrderRequest postOrderInput,
+  public ResponseEntity<Object> postOrder(@RequestBody @Valid PostOrderRequest postOrderInput,
       HttpServletRequest req) {
     String buyerId = req.getAttribute("buyerId").toString();
     Address address = new Address(postOrderInput.getPostalCode(), postOrderInput.getTodofuken(),

--- a/samples/web-csr/dressca-backend/web/src/test/java/com/dressca/web/controller/AssetsController.java
+++ b/samples/web-csr/dressca-backend/web/src/test/java/com/dressca/web/controller/AssetsController.java
@@ -66,7 +66,7 @@ public class AssetsController {
       @ApiResponse(responseCode = "404", description = "アセットコードに対応するアセットがない。", content = @Content(mediaType = "application/problem+json", schema = @Schema(implementation = ProblemDetail.class)))
   })
   @GetMapping("{assetCode}")
-  public ResponseEntity<?> get(
+  public ResponseEntity<Object> get(
       @Parameter(required = true, description = "アセットコード") @PathVariable("assetCode") String assetCode)
       throws LogicException {
     try {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

ワイルドカードを使用しているController のメソッドは正常系と異常系で異なるレスポンスボディの型を送るために設定されていました。
そのため、正常系と異常系で送るレスポンスボディがあるかどうかに基づいて、以下のように設定しました。

| Controller - Method | 正常系のレスポンスボディの有無 | 異常系のレスポンスボディの有無 | 対応方針 |
| --- | --- | --- | --- |
| AssetContoller - get | AssetResourceInfo | ProblemDetails | Object に設定 |
| BasketItemController - putBasketItems | 無し | ProblemDetails | ProblemDetails とすることも考えたが正常系にも ProblemDetails を使用すると誤認される恐れがあるため、可読性のために Object を設定 *1 |
| BasketItemController - postBasketItems | URI | ProblemDetails | Object に設定 |
| BasketItemController - deleteBasketItem | 無し | ProblemDetails | *1 と同様 |
| OrderController - getById | OrderResponse | ProblemDetails | Object に設定 |
| OrderController - postOrder | URI | ProblemDetails | Object に設定 |
| CatalogItemsController - deleteCatalogItem | 無し | 無し | ワイルドカードを使用(変更なし) |
| CatalogItemsController - putCatalogItem | 無し | 無し | ワイルドカードを使用(変更なし) |

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #2303 

<!-- I want to review in Japanese. -->