### PR TITLE
(admin)イベントバスを経由してユーザーへのアクションを行う

### DIFF
--- a/samples/web-csr/dressca-frontend/admin/package.json
+++ b/samples/web-csr/dressca-frontend/admin/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@heroicons/vue": "^2.2.0",
     "@vee-validate/yup": "^4.15.0",
+    "@vueuse/core": "^13.1.0",
     "axios": "^1.8.4",
     "msw": "2.7.3",
     "pinia": "^3.0.1",

--- a/samples/web-csr/dressca-frontend/admin/src/App.vue
+++ b/samples/web-csr/dressca-frontend/admin/src/App.vue
@@ -18,6 +18,8 @@ const { authenticationState, userName, userRoles } =
 const notificationStore = useNotificationStore();
 const { message, timeout } = storeToRefs(notificationStore);
 
+const injectedRouter = useRouter();
+
 /**
  * トーストの開閉状態です。
  */
@@ -34,9 +36,6 @@ const showLoginMenu = ref(false);
 const logout = async () => {
   await logoutAsync();
   showLoginMenu.value = !showLoginMenu.value;
-  const injectedRouter = useRouter();
-  // script setup の内部で実行するので、provide/inject が使えます。
-  // 直接 import したルーターと命名が被らないように変更しています。
   injectedRouter.push({ name: 'authentication/login' });
 };
 

--- a/samples/web-csr/dressca-frontend/admin/src/components/NotificationToast.vue
+++ b/samples/web-csr/dressca-frontend/admin/src/components/NotificationToast.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { ExclamationCircleIcon, XMarkIcon } from '@heroicons/vue/24/outline';
 import { watch } from 'vue';
+import { useEventBus } from '@vueuse/core';
+import { showToast } from '@/services/notification/notificationService';
+import { unhandledErrorEventKey } from '@/shared/events';
 
 /**
  * ユーザーにメッセージを通知するトーストです。
@@ -20,6 +23,9 @@ const timeout = defineModel('timeout', {
   required: true,
   default: 5000,
 });
+
+const unhandledErrorEventBus = useEventBus(unhandledErrorEventKey);
+unhandledErrorEventBus.on((payload) => showToast(payload.message));
 
 const close = () => {
   show.value = false;

--- a/samples/web-csr/dressca-frontend/admin/src/shared/error-handler/custom-error-handler.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/shared/error-handler/custom-error-handler.ts
@@ -54,9 +54,6 @@ export function createCustomErrorHandler(): CustomErrorHandler {
             unauthorizedErrorEventBus.emit({
               details: 'ログインしてください。',
             });
-            unhandledErrorEventBus.emit({
-              message: 'ログインしてください。',
-            });
           }
         } else if (error instanceof NetworkError) {
           if (handlingNetworkError) {

--- a/samples/web-csr/dressca-frontend/admin/src/shared/error-handler/custom-error-handler.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/shared/error-handler/custom-error-handler.ts
@@ -54,6 +54,9 @@ export function createCustomErrorHandler(): CustomErrorHandler {
             unauthorizedErrorEventBus.emit({
               details: 'ログインしてください。',
             });
+            unhandledErrorEventBus.emit({
+              message: 'ログインしてください。',
+            });
           }
         } else if (error instanceof NetworkError) {
           if (handlingNetworkError) {

--- a/samples/web-csr/dressca-frontend/admin/src/shared/events/index.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/shared/events/index.ts
@@ -1,0 +1,44 @@
+import type { EventBusKey } from '@vueuse/core';
+
+/**
+ * 想定外のエラーの発生を示すイベントのペイロードです。
+ * ユーザーへのトースト通知などに使用します。
+ */
+type UnhandledErrorEventPayload = {
+  /** ユーザーへ通知するメッセージ。 */
+  message: string;
+  /** エラーの ID （オプション） */
+  id?: string;
+  /** エラーのタイトル（オプション） */
+  title?: string;
+  /** エラーの詳細（オプション） */
+  detail?: string;
+  /** HTTPステータスコード（オプション） */
+  status?: number;
+  /** 通知のタイムアウト（ミリ秒、オプション） */
+  timeout?: number;
+};
+
+/**
+ * 未認証エラーの発生を示すイベントのペイロードです。
+ */
+type UnauthorizedErrorEventPayload = {
+  /** 詳細情報（例：リダイレクト先の情報やガイダンス） */
+  details: string;
+};
+
+/**
+ * 想定外のエラーの発生を示すイベントのキー値です。
+ * @example
+ * const unhandledErrorEventBus = useEventBus(unhandledErrorEventKey);
+ */
+export const unhandledErrorEventKey: EventBusKey<UnhandledErrorEventPayload> =
+  Symbol('unhandledErrorEventKey');
+
+/**
+ * 未認証エラーの発生を示すイベントのキー値です。
+ * @example
+ * const unauthorizedErrorEventBus = useEventBus(unauthorizedErrorEventKey);
+ */
+export const unauthorizedErrorEventKey: EventBusKey<UnauthorizedErrorEventPayload> =
+  Symbol('unauthorizedErrorEventKey');

--- a/samples/web-csr/dressca-frontend/package-lock.json
+++ b/samples/web-csr/dressca-frontend/package-lock.json
@@ -17,6 +17,7 @@
       "dependencies": {
         "@heroicons/vue": "^2.2.0",
         "@vee-validate/yup": "^4.15.0",
+        "@vueuse/core": "^13.1.0",
         "axios": "^1.8.4",
         "msw": "2.7.3",
         "pinia": "^3.0.1",


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと
- consumerで行った対応をadminに移植しました。

1. イベントバス構造を提供するVueUseのコンポーザブル（useEventBus）を導入しました。package.jsonに追加しています。
(https://vueuse.org/core/useEventBus/)
2. カスタムエラーハンドラーではイベントの発火を行い、各コンポーネントではイベントを購読してUIの変更処理を行う作りに変更しました。

### 再査してほしい挙動

- mockモードのレスポンスコードを変更して、想定通りのメッセージがトースト表示されることを確認してください。
    - 対象は 401（ログインしてください。）、500（サーバーエラーが発生しました。）
- 401 の場合、ログイン画面にリダイレクトされることを確認してください。
    - その際、URLのクエリパラメーターにルート名、パスパラメーター、クエリパラメーターが格納されていることを確認してください。
 - ネットワークエラーのシミュレーション時は、mockの戻り値をmswの機能を使って`HttpResponse.error()`で返すと再現できます。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク
consumerでの対応はこちら
- https://github.com/AlesInfiny/maia/pull/2259

<!-- I want to review in Japanese. -->