### PR TITLE
[consumer]カスタムエラーハンドラーのprovide injectをやめる

### DIFF
--- a/samples/web-csr/dressca-frontend/consumer/src/main.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/main.ts
@@ -2,7 +2,6 @@ import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import { authenticationGuard } from '@/shared/authentication/authentication-guard';
 import { globalErrorHandler } from '@/shared/error-handler/global-error-handler';
-import { createCustomErrorHandler } from '@/shared/error-handler/custom-error-handler';
 import App from './App.vue';
 import { router } from './router';
 import { i18n } from './locales/i18n';
@@ -39,7 +38,6 @@ app.use(createPinia());
 app.use(router);
 app.use(i18n);
 app.use(globalErrorHandler);
-app.use(createCustomErrorHandler());
 
 authenticationGuard(router);
 

--- a/samples/web-csr/dressca-frontend/consumer/src/shared/error-handler/custom-error-handler.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/shared/error-handler/custom-error-handler.ts
@@ -34,17 +34,17 @@ export function useCustomErrorHandler(): CustomErrorHandler {
     ) => {
       const unhandledErrorEventBus = useEventBus(unhandledErrorEventKey);
       const unauthorizedErrorEventBus = useEventBus(unauthorizedErrorEventKey);
-      // ハンドリングできるエラーの場合はコールバックを実行
+      // ハンドリングできるエラーの場合はコールバックを実行します。
       if (error instanceof CustomErrorBase) {
         callback();
 
         if (error instanceof HttpError) {
-          // 業務処理で発生した HttpError を処理する
+          // 業務処理で発生した HttpError を処理します。
           if (handlingHttpError) {
             handlingHttpError(error);
           }
           // エラーの種類によって共通処理を行う
-          // switch だと instanceof での判定ができないため if 文で判定
+          // switch だと instanceof での判定ができないため if 文で判定します。
           if (error instanceof UnauthorizedError) {
             if (handlingUnauthorizedError) {
               handlingUnauthorizedError();
@@ -52,7 +52,8 @@ export function useCustomErrorHandler(): CustomErrorHandler {
               unauthorizedErrorEventBus.emit({
                 details: t('loginRequiredError'),
               });
-              if (!error.response) {
+              // ProblemDetail の構造に依存します。
+              if (!error.response?.exceptionId) {
                 unhandledErrorEventBus.emit({
                   message: t('loginRequiredError'),
                 });
@@ -75,7 +76,7 @@ export function useCustomErrorHandler(): CustomErrorHandler {
             if (handlingNetworkError) {
               handlingNetworkError();
             } else {
-              // NetworkError ではエラーレスポンスが存在しないため ProblemDetails の処理は実施しない
+              // NetworkError ではエラーレスポンスが存在しないため ProblemDetails の処理は実施しません。
               unhandledErrorEventBus.emit({
                 message: t('networkError'),
               });
@@ -83,7 +84,8 @@ export function useCustomErrorHandler(): CustomErrorHandler {
           } else if (error instanceof ServerError) {
             if (handlingServerError) {
               handlingServerError();
-            } else if (!error.response) {
+              // ProblemDetail の構造に依存します。
+            } else if (!error.response?.exceptionId) {
               unhandledErrorEventBus.emit({
                 message: t('serverError'),
               });
@@ -104,7 +106,7 @@ export function useCustomErrorHandler(): CustomErrorHandler {
           }
         }
       } else {
-        // ハンドリングできないエラーの場合は上位にエラーを投げる
+        // ハンドリングできないエラーの場合は上位にエラーを再スローします。
         throw error;
       }
     },

--- a/samples/web-csr/dressca-frontend/consumer/src/shared/error-handler/custom-error-handler.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/shared/error-handler/custom-error-handler.ts
@@ -1,5 +1,3 @@
-import type { App } from 'vue';
-import { customErrorHandlerKey } from '@/shared/injection-symbols';
 import { i18n } from '@/locales/i18n';
 import { errorMessageFormat } from '@/shared/error-handler/error-message-format';
 import { useEventBus } from '@vueuse/core';
@@ -13,7 +11,6 @@ import {
 import { unauthorizedErrorEventKey, unhandledErrorEventKey } from '../events';
 
 export interface CustomErrorHandler {
-  install(app: App): void;
   handle(
     error: unknown,
     callback: () => void,
@@ -24,12 +21,9 @@ export interface CustomErrorHandler {
   ): void;
 }
 
-export function createCustomErrorHandler(): CustomErrorHandler {
+export function useCustomErrorHandler(): CustomErrorHandler {
   const { t } = i18n.global;
   const customErrorHandler: CustomErrorHandler = {
-    install: (app: App) => {
-      app.provide(customErrorHandlerKey, customErrorHandler);
-    },
     handle: (
       error: unknown,
       callback: () => void,

--- a/samples/web-csr/dressca-frontend/consumer/src/shared/error-handler/use-custom-error-handler.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/shared/error-handler/use-custom-error-handler.ts
@@ -1,7 +1,0 @@
-import { inject } from 'vue';
-import type { CustomErrorHandler } from './custom-error-handler';
-import { customErrorHandlerKey } from '../injection-symbols';
-
-export function useCustomErrorHandler(): CustomErrorHandler {
-  return inject(customErrorHandlerKey)!;
-}

--- a/samples/web-csr/dressca-frontend/consumer/src/shared/injection-symbols.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/shared/injection-symbols.ts
@@ -1,6 +1,0 @@
-import type { InjectionKey } from 'vue';
-import type { CustomErrorHandler } from './error-handler/custom-error-handler';
-
-export const customErrorHandlerKey = Symbol(
-  'customErrorHandler',
-) as InjectionKey<CustomErrorHandler>;

--- a/samples/web-csr/dressca-frontend/consumer/src/views/__tests__/basket/BasketView.spec.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/__tests__/basket/BasketView.spec.ts
@@ -3,7 +3,6 @@ import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
 import { router } from '@/router';
 import { i18n } from '@/locales/i18n';
 import { createTestingPinia } from '@pinia/testing';
-import { createCustomErrorHandler } from '@/shared/error-handler/custom-error-handler';
 import BasketView from '@/views/basket/BasketView.vue';
 import type { BasketResponse } from '@/generated/api-client';
 import { ServerError } from '@/shared/error-handler/custom-error';
@@ -88,9 +87,8 @@ async function getWrapper() {
     stubActions: false, // 結合テストなので、アクションはモック化しないように設定します。
   });
   i18n.global.locale.value = 'ja'; // デフォルトの jsdom 環境では英語（en）に設定されるので、日本語に変更します。
-  const customErrorHandler = createCustomErrorHandler();
   return mount(BasketView, {
-    global: { plugins: [pinia, router, i18n, customErrorHandler] },
+    global: { plugins: [pinia, router, i18n] },
   });
 }
 

--- a/samples/web-csr/dressca-frontend/consumer/src/views/basket/BasketView.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/basket/BasketView.vue
@@ -14,9 +14,9 @@ import { LoadingSpinnerOverlay } from '@/components/common/LoadingSpinnerOverlay
 import { currencyHelper } from '@/shared/helpers/currencyHelper';
 import { assetHelper } from '@/shared/helpers/assetHelper';
 import { storeToRefs } from 'pinia';
-import { useCustomErrorHandler } from '@/shared/error-handler/use-custom-error-handler';
 import { errorMessageFormat } from '@/shared/error-handler/error-message-format';
 import { HttpError } from '@/shared/error-handler/custom-error';
+import { useCustomErrorHandler } from '@/shared/error-handler/custom-error-handler';
 
 const showLoading = ref(true);
 

--- a/samples/web-csr/dressca-frontend/consumer/src/views/catalog/CatalogView.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/catalog/CatalogView.vue
@@ -14,10 +14,10 @@ import { LoadingSpinnerOverlay } from '@/components/common/LoadingSpinnerOverlay
 import { useRouter } from 'vue-router';
 import { currencyHelper } from '@/shared/helpers/currencyHelper';
 import { assetHelper } from '@/shared/helpers/assetHelper';
-import { useCustomErrorHandler } from '@/shared/error-handler/use-custom-error-handler';
 import { i18n } from '@/locales/i18n';
 import { errorMessageFormat } from '@/shared/error-handler/error-message-format';
 import { HttpError } from '@/shared/error-handler/custom-error';
+import { useCustomErrorHandler } from '@/shared/error-handler/custom-error-handler';
 
 const specialContentStore = useSpecialContentStore();
 const catalogStore = useCatalogStore();

--- a/samples/web-csr/dressca-frontend/consumer/src/views/ordering/CheckoutView.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/ordering/CheckoutView.vue
@@ -9,10 +9,10 @@ import { useRouter } from 'vue-router';
 import { currencyHelper } from '@/shared/helpers/currencyHelper';
 import { assetHelper } from '@/shared/helpers/assetHelper';
 import { storeToRefs } from 'pinia';
-import { useCustomErrorHandler } from '@/shared/error-handler/use-custom-error-handler';
 import { i18n } from '@/locales/i18n';
 import { errorMessageFormat } from '@/shared/error-handler/error-message-format';
 import { HttpError } from '@/shared/error-handler/custom-error';
+import { useCustomErrorHandler } from '@/shared/error-handler/custom-error-handler';
 
 const userStore = useUserStore();
 const basketStore = useBasketStore();

--- a/samples/web-csr/dressca-frontend/consumer/src/views/ordering/DoneView.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/ordering/DoneView.vue
@@ -7,10 +7,10 @@ import { showToast } from '@/services/notification/notificationService';
 import type { OrderResponse } from '@/generated/api-client/models/order-response';
 import { currencyHelper } from '@/shared/helpers/currencyHelper';
 import { assetHelper } from '@/shared/helpers/assetHelper';
-import { useCustomErrorHandler } from '@/shared/error-handler/use-custom-error-handler';
 import { errorMessageFormat } from '@/shared/error-handler/error-message-format';
 import { HttpError } from '@/shared/error-handler/custom-error';
 import { LoadingSpinnerOverlay } from '@/components/common/LoadingSpinnerOverlay';
+import { useCustomErrorHandler } from '@/shared/error-handler/custom-error-handler';
 
 const router = useRouter();
 const customErrorHandler = useCustomErrorHandler();


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと
- イベントバスの導入によって循環参照を避けることができるようになったので、スタムエラーハンドラーをmain.ts で provideし各コンポーネントでinjectするつくりをやめ、シンプル化しました。
- responseはあるがProblemDetailsの独自プロパティがない場合に、メッセージの整形に失敗して想定外のエラーになる既存の不具合について、条件を、
`if (!error.response?.exceptionId) {`
としてexceptionIdをチェックすることで暫定的に対処しました。最終的にやりたいことは下記のissueに関連します。
    - https://github.com/AlesInfiny/maia/issues/2258
- コメントの日本語が敬体になっていない箇所を敬体に修正しました。

### 再査してほしいケース
- mock の戻り値を変更して、カスタムエラーハンドラーに実装された共通処理（トーストに通知が行われることや、ログイン画面にリダイレクトが行われること）が行われることを確認してください。
- その際、Vue等の想定外の警告やエラーが開発者コンソールに出ないことを確認してください。
- 挙動を確認してほしいステータスコードは、
    - 500、 401、ネットワークエラー（`HttpRespones.Error()`）です。

## この Pull request では実施していないこと

adminは別PRで実施します。

## Issues や Discussions 、関連する Web サイトなどへのリンク
- 命名は少し迷いましたが、現在の呼び出し側に影響が最も少なくなるように`useCustomErrorHandler()`経由で取得するようにしました。下記のissueなどでcomposablesのような命名のフォルダに移動してもよさそうと思っています。
    - https://github.com/AlesInfiny/maia/issues/2240

<!-- I want to review in Japanese. -->