### PR TITLE
[AzureADB2CAuth] TypeScript 5.8.3 にアップグレードする

### DIFF
--- a/samples/azure-ad-b2c-sample/auth-frontend/app/package.json
+++ b/samples/azure-ad-b2c-sample/auth-frontend/app/package.json
@@ -11,7 +11,7 @@
     "build-only:dev": "vite build --mode dev",
     "preview": "vite preview",
     "test:unit": "vitest",
-    "type-check": "vue-tsc --build --force",
+    "type-check": "vue-tsc --build",
     "lint": "run-p eslint format",
     "lint:ci": "run-p eslint:ci format:ci",
     "eslint": "eslint . --fix",
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "2.20.2",
-    "@tsconfig/node20": "20.1.5",
+    "@tsconfig/node22": "22.0.2",
     "@types/jsdom": "21.1.7",
     "@types/node": "22.15.29",
     "@vitejs/plugin-vue": "5.2.4",
@@ -50,7 +50,7 @@
     "jsdom": "26.1.0",
     "npm-run-all2": "8.0.4",
     "prettier": "3.5.3",
-    "typescript": "5.3.3",
+    "typescript": "5.8.3",
     "vite": "6.3.5",
     "vitest": "3.2.0",
     "vue-tsc": "2.2.10"

--- a/samples/azure-ad-b2c-sample/auth-frontend/app/tsconfig.app.json
+++ b/samples/azure-ad-b2c-sample/auth-frontend/app/tsconfig.app.json
@@ -3,9 +3,7 @@
   "include": ["env.d.ts", "src/**/*", "src/**/*.vue", "mock/**/*"],
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
-    "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },

--- a/samples/azure-ad-b2c-sample/auth-frontend/app/tsconfig.json
+++ b/samples/azure-ad-b2c-sample/auth-frontend/app/tsconfig.json
@@ -9,8 +9,9 @@
     },
     {
       "path": "./tsconfig.vitest.json"
-    }],
-    "compilerOptions": {
-      "module": "NodeNext"
     }
+  ],
+  "compilerOptions": {
+    "module": "NodeNext"
+  }
 }

--- a/samples/azure-ad-b2c-sample/auth-frontend/app/tsconfig.node.json
+++ b/samples/azure-ad-b2c-sample/auth-frontend/app/tsconfig.node.json
@@ -1,8 +1,7 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "include": ["vite.config.*", "vitest.config.*", "cypress.config.*"],
   "compilerOptions": {
-    "composite": true,
     "noEmit": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "module": "ESNext",

--- a/samples/azure-ad-b2c-sample/auth-frontend/app/tsconfig.vitest.json
+++ b/samples/azure-ad-b2c-sample/auth-frontend/app/tsconfig.vitest.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.app.json",
   "exclude": [],
   "compilerOptions": {
-    "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
     "lib": [],
     "types": ["node", "jsdom"]

--- a/samples/azure-ad-b2c-sample/auth-frontend/package-lock.json
+++ b/samples/azure-ad-b2c-sample/auth-frontend/package-lock.json
@@ -23,7 +23,7 @@
       },
       "devDependencies": {
         "@openapitools/openapi-generator-cli": "2.20.2",
-        "@tsconfig/node20": "20.1.5",
+        "@tsconfig/node22": "22.0.2",
         "@types/jsdom": "21.1.7",
         "@types/node": "22.15.29",
         "@vitejs/plugin-vue": "5.2.4",
@@ -41,7 +41,7 @@
         "jsdom": "26.1.0",
         "npm-run-all2": "8.0.4",
         "prettier": "3.5.3",
-        "typescript": "5.3.3",
+        "typescript": "5.8.3",
         "vite": "6.3.5",
         "vitest": "3.2.0",
         "vue-tsc": "2.2.10"
@@ -2263,10 +2263,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.5",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.5.tgz",
-      "integrity": "sha512-Vm8e3WxDTqMGPU4GATF9keQAIy1Drd7bPwlgzKJnZtoOsTm1tduUTbDjg0W5qERvGuxPI2h9RbMufH0YdfBylA==",
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.2.tgz",
+      "integrity": "sha512-Kmwj4u8sDRDrMYRoN9FDEcXD8UpBSaPQQ24Gz+Gamqfm7xxn+GBR7ge/Z7pK8OXNGyUzbSwJj+TH6B+DS/epyA==",
       "dev": true,
       "license": "MIT"
     },
@@ -7200,9 +7200,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

-TypeScript 5.8.3 にアップグレードしました。
    - `npm list -all typescript` を実行し、すべてのパッケージがTypescript 5.8.3 を使用していることを確認しました。
-あわせてTypeScritp の設定ファイル tsconfig について、create-vue 3.16.4 に追従するよう変更しました。

- 各変更箇所とその理由はコメントに記載しますので、確認しましたら resolve をお願いします。

## この Pull request では実施していないこと

Dresscaへの対応は別PRで実施予定です。
ドキュメントの更新はDresscaの対応後に別PRで実施予定です。

## Issues や Discussions 、関連する Web サイトなどへのリンク

- https://github.com/AlesInfiny/maia/issues/2604

<!-- I want to review in Japanese. -->