### PR TITLE
VitestとCypressのテストスイートの検索がうまくできていない不具合を修正

### DIFF
--- a/samples/azure-ad-b2c-sample/auth-frontend/eslint.config.ts
+++ b/samples/azure-ad-b2c-sample/auth-frontend/eslint.config.ts
@@ -70,13 +70,16 @@ export default defineConfigWithVueTs(
   // Vitest 用のテストスイートに対して、 Vitest 推奨の Lint ルールを適用します。
   {
     ...pluginVitest.configs.recommended,
-    files: ['src/**/__tests__/**/*'],
+    files: ['**/src/**/__tests__/**/*'],
   },
 
   // Cypress 用のテストスイートに対して、Cypress 推奨の Lint ルールを適用します。
   {
     ...pluginCypress.configs.recommended,
-    files: ['cypress/e2e/**/*.{cy,spec}.{js,ts,jsx,tsx}', 'cypress/support/**/*.{js,ts,jsx,tsx}'],
+    files: [
+      '**/cypress/e2e/**/*.{cy,spec}.{js,ts,jsx,tsx}',
+      '**/cypress/support/**/*.{js,ts,jsx,tsx}',
+    ],
   },
   // コードのフォーマットは Prettier で実行するので、 ESLint のフォーマットルールは無効化します。
   skipFormatting,

--- a/samples/web-csr/dressca-frontend/eslint.config.ts
+++ b/samples/web-csr/dressca-frontend/eslint.config.ts
@@ -36,7 +36,7 @@ export default defineConfigWithVueTs(
     languageOptions: {
       parserOptions: {
         projectService: true,
-        tsconfigRootDir: import.meta.dirname
+        tsconfigRootDir: import.meta.dirname,
       },
     },
   },
@@ -70,13 +70,16 @@ export default defineConfigWithVueTs(
   // Vitest 用のテストスイートに対して、 Vitest 推奨の Lint ルールを適用します。
   {
     ...pluginVitest.configs.recommended,
-    files: ['src/**/__tests__/**/*'],
+    files: ['**/src/**/__tests__/**/*'],
   },
 
   // Cypress 用のテストスイートに対して、Cypress 推奨の Lint ルールを適用します。
   {
     ...pluginCypress.configs.recommended,
-    files: ['cypress/e2e/**/*.{cy,spec}.{js,ts,jsx,tsx}', 'cypress/support/**/*.{js,ts,jsx,tsx}'],
+    files: [
+      '**/cypress/e2e/**/*.{cy,spec}.{js,ts,jsx,tsx}',
+      '**/cypress/support/**/*.{js,ts,jsx,tsx}',
+    ],
   },
   // コードのフォーマットは Prettier で実行するので、 ESLint のフォーマットルールは無効化します。
   skipFormatting,


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと
- VitestとCypressのESLintルールについて、検索対象のファイルパスを指定するglobの先頭に`**`を追加しました。

### 証跡
下記の完了条件について、Vitest、Cypressそれぞれコメントに記載します。
- [ ] vitestのESLint 用プラグインのルールがテストスイートに適用されること
- [ ] admin と consumer の両方に問題があるケースで、 admin での実行では admin のみ、 consumer の実行では consumer のみのエラーが出力されること

## この Pull request では実施していないこと
AzureADB2Cについてはワークスペースが複数ないので、机上での確認のみしています。
ドキュメントの修正は下記のPRに追加でプッシュします。
- https://github.com/AlesInfiny/maia/pull/2754

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->