### PR TITLE
dependencies.gradleのガイドにlog4j2の依存関係を追加

### DIFF
--- a/documents/contents/guidebooks/how-to-develop/java/sub-project-settings/project-version-control.md
+++ b/documents/contents/guidebooks/how-to-develop/java/sub-project-settings/project-version-control.md
@@ -29,6 +29,7 @@ ext {
     spring_boot_starter_web : "org.springframework.boot:spring-boot-starter-web",
     spring_boot_starter_actuator : "org.springframework.boot:spring-boot-starter-actuator",
     spring_boot_starter_test : 'org.springframework.boot:spring-boot-starter-test',
+    spring_boot_starter_log4j2 : "org.springframework.boot:spring-boot-starter-log4j2",
     springdoc_openapi_starter_webmvc_ui : "org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocOpenapiVersion",
     h2database : "com.h2database:h2:$h2Version",
   ]


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

バックエンドライブラリのバージョンを一元管理するdependencies.gradleのガイドに、log4j2の依存関係が抜け落ちていたので追記しました。

## この Pull request では実施していないこと

以下に示すように、今回追記した`org.springframework.boot:spring-boot-starter-log4j2`にSLF4Jの依存関係は含まれているため、
SLF4Jに関する個別のライブラリは追加していません。

```terminal
+--- org.springframework.boot:spring-boot-starter-log4j2 -> 3.5.3
|    +--- org.apache.logging.log4j:log4j-slf4j2-impl:2.24.3
|    |    +--- org.apache.logging.log4j:log4j-api:2.24.3
|    |    +--- org.slf4j:slf4j-api:2.0.16 -> 2.0.17
|    |    \--- org.apache.logging.log4j:log4j-core:2.24.3
|    |         \--- org.apache.logging.log4j:log4j-api:2.24.3
|    +--- org.apache.logging.log4j:log4j-core:2.24.3 (*)
|    \--- org.apache.logging.log4j:log4j-jul:2.24.3
|         \--- org.apache.logging.log4j:log4j-api:2.24.3
```
## Issues や Discussions 、関連する Web サイトなどへのリンク
- #2837 

<!-- I want to review in Japanese. -->