### PR TITLE
TypeScriptのコード例の文末セミコロンを削除またはスニペットのリンクに置き換え

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -55,6 +55,7 @@
         "Noto",
         "PKCE",
         "Pinia",
+        "Pygments",
         "Pymarkdown",
         "pymdown",
         "Tasklet",

--- a/documents/README.md
+++ b/documents/README.md
@@ -158,7 +158,7 @@ AlesInfiny Maia の GitHub コードをドキュメントで参照する場合�
     ```md
     ??? example "App.vue の設定例"
 
-        ```html title="サンプルアプリケーションの App.vue" hl_lines="1 3-4"
+        ```vue title="サンプルアプリケーションの App.vue" hl_lines="1 3-4"
         https://github.com/AlesInfiny/maia/blob/main/samples/web-csr/dressca-frontend/consumer/src/App.vue
         ```
     ```
@@ -171,7 +171,7 @@ AlesInfiny Maia の GitHub コードをドキュメントで参照する場合�
     ```md
     !!! example "App.vue の設定例"
 
-        ```html title="サンプルアプリケーションの App.vue" hl_lines="1 3-4"
+        ```vue title="サンプルアプリケーションの App.vue" hl_lines="1 3-4"
         https://github.com/AlesInfiny/maia/blob/main/samples/web-csr/dressca-frontend/consumer/src/App.vue#L1-L8
         ```
     ```

--- a/documents/README.md
+++ b/documents/README.md
@@ -176,6 +176,9 @@ AlesInfiny Maia の GitHub コードをドキュメントで参照する場合�
         ```
     ```
 
+コードブロックのシンタックスハイライトが利用可能な言語の一覧は、[Pygments - Languages](https://pygments.org/languages/) を参照してください。
+また、複数の表記方法が可能な場合、略称よりも正式名称に近いものを優先してください。（例： ts ではなく typescript を使用）
+
 ### 体裁の修正
 
 #### markdownlint

--- a/documents/contents/app-architecture/client-side-rendering/frontend-application/index.md
+++ b/documents/contents/app-architecture/client-side-rendering/frontend-application/index.md
@@ -202,7 +202,7 @@ src/
                component: () => import('@/views/authentication/LoginView.vue'),
             },
          ],
-      });
+      })
       ```
 
 ### components フォルダー {#components-directory}

--- a/documents/contents/app-architecture/security/xss.md
+++ b/documents/contents/app-architecture/security/xss.md
@@ -56,7 +56,7 @@ description: アプリケーションセキュリティを 担保するための
 
     `v-html` や描画関数を使用してアプリケーション外から取得した値をそのまま出力してはなりません。
 
-    ```js title="XSS に対して脆弱なコード例①"
+    ```typescript title="XSS に対して脆弱なコード例①"
     new Vue({
         el: '#app',
         template: `<div>` + アプリケーション外から取得した値 + `</div>`

--- a/documents/contents/guidebooks/how-to-develop/cors/index.md
+++ b/documents/contents/guidebooks/how-to-develop/cors/index.md
@@ -134,7 +134,7 @@ Spring Boot では、 CORS に関する設定を `SecurityFilterChain` を利用
 
 AlesInfiny Maia では Web API 呼び出しの共通処理用に `./src/api-client/index.ts` という設定ファイルを作成する（ [参照](../vue-js/create-api-client-code.md#set-client-code) ）ので、ここで HTTP ヘッダーを設定します。
 
-```ts title="index.ts" hl_lines="11"
+```typescript title="index.ts" hl_lines="11"
 import axios from 'axios'
 import * as apiClient from '@/generated/api-client'
 

--- a/documents/contents/guidebooks/how-to-develop/cors/index.md
+++ b/documents/contents/guidebooks/how-to-develop/cors/index.md
@@ -135,8 +135,8 @@ Spring Boot では、 CORS に関する設定を `SecurityFilterChain` を利用
 AlesInfiny Maia では Web API 呼び出しの共通処理用に `./src/api-client/index.ts` という設定ファイルを作成する（ [参照](../vue-js/create-api-client-code.md#set-client-code) ）ので、ここで HTTP ヘッダーを設定します。
 
 ```ts title="index.ts" hl_lines="11"
-import axios from 'axios';
-import * as apiClient from '@/generated/api-client';
+import axios from 'axios'
+import * as apiClient from '@/generated/api-client'
 
 // （中略）
 
@@ -148,9 +148,9 @@ const axiosInstance = axios.create({
   withCredentials: true,
 });
 
-const exampleApi = new apiClient.ExampleApi(createConfig(), '', axiosInstance);
+const exampleApi = new apiClient.ExampleApi(createConfig(), '', axiosInstance)
 
-export { exampleApi };
+export { exampleApi }
 ```
 
 <!-- textlint-disable @textlint-ja/no-synonyms -->

--- a/documents/contents/guidebooks/how-to-develop/cors/index.md
+++ b/documents/contents/guidebooks/how-to-develop/cors/index.md
@@ -146,7 +146,7 @@ const axiosInstance = axios.create({
     'Content-Type': 'application/json',
   },
   withCredentials: true,
-});
+})
 
 const exampleApi = new apiClient.ExampleApi(createConfig(), '', axiosInstance)
 

--- a/documents/contents/guidebooks/how-to-develop/vue-js/create-api-client-code.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/create-api-client-code.md
@@ -100,20 +100,20 @@ npm run generate-client
 `./src/api-client/index.ts` というファイルを作成し、以下のように設定します。
 
 ```typescript title="index.ts"
-import axios from 'axios';
-import * as apiClient from '@/generated/api-client';
+import axios from 'axios'
+import * as apiClient from '@/generated/api-client'
 
 function createConfig(): apiClient.Configuration {
   const config = new apiClient.Configuration({
   });
-  return config;
+  return config
 }
 
-const axiosInstance = axios.create({});
+const axiosInstance = axios.create({})
 
-const defaultApi = new apiClient.DefaultApi(createConfig(), '', axiosInstance);
+const defaultApi = new apiClient.DefaultApi(createConfig(), '', axiosInstance)
 
-export { defaultApi };
+export { defaultApi }
 ```
 
 - `apiClient.Configuration` : api-client の共通の Configuration があればここに定義します。プロパティの詳細は [こちら :material-open-in-new:](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/typescript-axios/configuration.mustache){ target=_blank }を参照してください。
@@ -126,7 +126,7 @@ export { defaultApi };
 1. 生成したインスタンスを `export` します。
 
 ??? info "BaseAPI のコンストラクター"
-    - `BaseAPI(configuration?: Configuration, basePath?: string, axios?: AxiosInstance)`
+    - `BaseAPI(configuration?: Configuration, basePath: string, axios: AxiosInstance)`
 
     `BaseAPI` は OpenAPI Generator で自動生成されるコードの `base.ts` に含まれるクラスです。
     各 API が継承している `BaseAPI` コンストラクターの引数に api-client の共通設定、ベースパス[^1]、 axios インスタンスを設定することで、 API に関するグローバルな設定を適用します。
@@ -138,16 +138,7 @@ export { defaultApi };
     [^1]: ベースパスは `https://www.example.com` のようなリンク先の基準となる URL です。
 
     ```typescript title="base.ts"
-    export class BaseAPI {
-      protected configuration: Configuration | undefined;
-
-      constructor(configuration?: Configuration, protected basePath: string = BASE_PATH, protected axios: AxiosInstance = globalAxios) {
-        if (configuration) {
-            this.configuration = configuration;
-            this.basePath = configuration.basePath ?? this.basePath;
-        }
-      }
-    };
+      https://github.com/AlesInfiny/maia/blob/main/samples/web-csr/dressca-frontend/consumer/src/generated/api-client/base.ts#L50-L59
     ```
 
 [^2]: ジェネレーターに `"typescript-axios"` を使用する場合に設定可能な値は [こちら :material-open-in-new:](https://openapi-generator.tech/docs/generators/typescript-axios){ target=_blank }を参照ください。

--- a/documents/contents/guidebooks/how-to-develop/vue-js/create-api-client-code.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/create-api-client-code.md
@@ -105,7 +105,7 @@ import * as apiClient from '@/generated/api-client'
 
 function createConfig(): apiClient.Configuration {
   const config = new apiClient.Configuration({
-  });
+  })
   return config
 }
 

--- a/documents/contents/guidebooks/how-to-develop/vue-js/error-handler-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/error-handler-settings.md
@@ -71,7 +71,7 @@ description: Vue.js を用いた フロントエンドアプリケーション�
 
 ??? example "エントリーポイントの実装例"
 
-    ``` ts title="main.ts" hl_lines="3 12"
+    ```typescript title="main.ts" hl_lines="3 12"
     import { createApp } from 'vue'
     import { createPinia } from 'pinia'
     import { globalErrorHandler } from '@/shared/error-handler/global-error-handler'

--- a/documents/contents/guidebooks/how-to-develop/vue-js/error-handler-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/error-handler-settings.md
@@ -36,7 +36,7 @@ description: Vue.js を用いた フロントエンドアプリケーション�
 
     <!-- textlint-enable ja-technical-writing/sentence-length -->
 
-    ```ts title="global-error-handler.ts"
+    ```typescript title="global-error-handler.ts"
     import type { App, ComponentPublicInstance } from 'vue'
     import { router } from '../../router'
 

--- a/documents/contents/guidebooks/how-to-develop/vue-js/error-handler-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/error-handler-settings.md
@@ -50,17 +50,17 @@ description: Vue.js を用いた フロントエンドアプリケーション�
           // Vue.js アプリケーションでのエラー発生時に実行したい処理
           console.error(err, instance, info)
           router.replace({ name: 'error' })
-        };
+        }
 
         window.addEventListener('error', (event) => {
           // 同期処理でのエラー発生時に実行したい処理
           console.error(event)
-        });
+        })
 
         window.addEventListener('unhandledrejection', (event) => {
           // 非同期処理でのエラー発生時に実行したい処理
           console.error(event)
-        });
+        })
       },
     };
     ```

--- a/documents/contents/guidebooks/how-to-develop/vue-js/error-handler-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/error-handler-settings.md
@@ -37,8 +37,8 @@ description: Vue.js を用いた フロントエンドアプリケーション�
     <!-- textlint-enable ja-technical-writing/sentence-length -->
 
     ```ts title="global-error-handler.ts"
-    import type { App, ComponentPublicInstance } from 'vue';
-    import { router } from '../../router';
+    import type { App, ComponentPublicInstance } from 'vue'
+    import { router } from '../../router'
 
     export const globalErrorHandler = {
       install(app: App) {
@@ -48,18 +48,18 @@ description: Vue.js を用いた フロントエンドアプリケーション�
           info: string,
         ) => {
           // Vue.js アプリケーションでのエラー発生時に実行したい処理
-          console.error(err, instance, info);
-          router.replace({ name: 'error' });
+          console.error(err, instance, info)
+          router.replace({ name: 'error' })
         };
 
         window.addEventListener('error', (event) => {
           // 同期処理でのエラー発生時に実行したい処理
-          console.error(event);
+          console.error(event)
         });
 
         window.addEventListener('unhandledrejection', (event) => {
           // 非同期処理でのエラー発生時に実行したい処理
-          console.error(event);
+          console.error(event)
         });
       },
     };
@@ -72,18 +72,18 @@ description: Vue.js を用いた フロントエンドアプリケーション�
 ??? example "エントリーポイントの実装例"
 
     ``` ts title="main.ts" hl_lines="3 12"
-    import { createApp } from 'vue';
-    import { createPinia } from 'pinia';
-    import { globalErrorHandler } from '@/shared/error-handler/global-error-handler';
-    import App from './App.vue';
-    import { router } from './router';
+    import { createApp } from 'vue'
+    import { createPinia } from 'pinia'
+    import { globalErrorHandler } from '@/shared/error-handler/global-error-handler'
+    import App from './App.vue'
+    import { router } from './router'
 
-    const app = createApp(App);
+    const app = createApp(App)
 
-    app.use(createPinia());
-    app.use(router);
+    app.use(createPinia())
+    app.use(router)
 
-    app.use(globalErrorHandler);
+    app.use(globalErrorHandler)
 
-    app.mount('#app');
+    app.mount('#app')
     ```

--- a/documents/contents/guidebooks/how-to-develop/vue-js/input-validation.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/input-validation.md
@@ -37,7 +37,7 @@ https://github.com/AlesInfiny/maia/blob/main/samples/web-csr/dressca-frontend/co
 
 作成したファイルを読み込むため、 入力値を検証する Vue ファイルのスクリプト構文に以下を記述します。
 
-```ts title="example.vue"
+```vue title="example.vue"
 <script setup lang="ts">
 import { configureYup } from '@/config/yup.config'
 

--- a/documents/contents/guidebooks/how-to-develop/vue-js/input-validation.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/input-validation.md
@@ -23,10 +23,7 @@ npm install vee-validate yup vue-i18n
 メッセージを多言語対応する場合には、それぞれの言語の JSON ファイルを作成し、各言語のメッセージをフォルダーで分割して管理します。
 
 ```json title="validationTextList_jp.json"
-{
-  "email": "メールアドレスの形式で入力してください",
-  "required": "値を入力してください"
-}
+https://github.com/AlesInfiny/maia/blob/main/samples/web-csr/dressca-frontend/consumer/src/locales/ja/validationTextList_ja.json
 ```
 
 ## 入力値検証時の設定 {#settings-validation}
@@ -35,36 +32,23 @@ npm install vee-validate yup vue-i18n
 [アーキテクチャ定義](../../../app-architecture/client-side-rendering/frontend-application/index.md#project-structure) では設定ファイルは `./src/config` フォルダーに集約されるため、ファイル `./src/config/yup.config.ts` を作成し、以下のように記述します。
 
 ```typescript title="yup.config.ts"
-import { i18n } from '@/locales/i18n';
-import { setLocale } from 'yup';
-
-export function configureYup(): void {
-  const { t } = i18n.global;
-  setLocale({
-    mixed: {
-      required: t('required'),
-    },
-    string: {
-      email: t('email'),
-    },
-  });
-}
+https://github.com/AlesInfiny/maia/blob/main/samples/web-csr/dressca-frontend/consumer/src/config/yup.config.ts
 ```
 
 作成したファイルを読み込むため、 入力値を検証する Vue ファイルのスクリプト構文に以下を記述します。
 
-```vue title="example.vue"
+```ts title="example.vue"
 <script setup lang="ts">
-import { configureYup } from '@/config/yup.config';
+import { configureYup } from '@/config/yup.config'
 
 // yup設定の有効化
-configureYup();
+configureYup()
 
 // フォーム固有のバリデーション定義
 const formSchema = yup.object({
   email: ValidationItems().email.required(),
   password: yup.string().required(),
-});
+})
 </script>
 ```
 

--- a/documents/contents/guidebooks/how-to-develop/vue-js/message-management.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/message-management.md
@@ -65,7 +65,7 @@ JSON ファイルでメッセージを管理する際は、メッセージコー
 
 メッセージ本体を格納する JSON ファイルを読み込むために、以下のように `i18n.ts` を実装します。
 
-```ts title="i18n.ts"
+```typescript title="i18n.ts"
 https://github.com/AlesInfiny/maia/blob/main/samples/web-csr/dressca-frontend/consumer/src/locales/i18n.ts
 ```
 
@@ -94,7 +94,7 @@ https://github.com/AlesInfiny/maia/blob/main/samples/web-csr/dressca-frontend/co
 
 `i18n.ts` の設定をアプリケーションに反映させるため、 `main.ts` に以下のように実装します。
 
-```ts title="main.ts" hl_lines="6 14"
+```typescript title="main.ts" hl_lines="6 14"
 import { createApp } from "vue"
 import { createPinia } from "pinia"
 import { authenticationGuard } from "@/shared/authentication/authentication-guard"
@@ -120,7 +120,7 @@ app.mount("#app")
 読み込んだメッセージを取得するためには、 `i18n.ts` を各ファイルでインポートして利用します。
 実装例は以下の通りです。
 
-```ts title="メッセージ利用例"
+```vue title="メッセージ利用例"
 <script setup lang="ts">
 import { i18n } from '@/locales/i18n'
 

--- a/documents/contents/guidebooks/how-to-develop/vue-js/message-management.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/message-management.md
@@ -66,31 +66,7 @@ JSON ファイルでメッセージを管理する際は、メッセージコー
 メッセージ本体を格納する JSON ファイルを読み込むために、以下のように `i18n.ts` を実装します。
 
 ```ts title="i18n.ts"
-import { createI18n } from "vue-i18n";
-import messageListEN from '@/locales/en/messageList_en.json';
-import messageListJA from '@/locales/ja/messageList_ja.json';
-import validationTextListJA from '@/locales/ja/validationTextList_ja.json';
-import validationTextListEN from '@/locales/en/validationTextList_en.json';
-
-const langPackage = {
-  ja: {
-    ...messageListJA,
-    ...validationTextListJA,
-  },
-  en: {
-    ...messageListEN,
-    ...validationTextListEN,
-  },
-};
-
-const i18n = createI18n({
-  legacy: false,
-  locale: window.navigator.language,
-  fallbackLocale: "en",
-  messages: langPackage,
-});
-
-export { i18n };
+https://github.com/AlesInfiny/maia/blob/main/samples/web-csr/dressca-frontend/consumer/src/locales/i18n.ts
 ```
 
 メッセージ管理機能を導入するための `createI18n` の引数の役割は以下の通りです。
@@ -119,24 +95,24 @@ export { i18n };
 `i18n.ts` の設定をアプリケーションに反映させるため、 `main.ts` に以下のように実装します。
 
 ```ts title="main.ts" hl_lines="6 14"
-import { createApp } from "vue";
-import { createPinia } from "pinia";
-import { authenticationGuard } from "@/shared/authentication/authentication-guard";
-import App from "./App.vue";
-import { router } from "./router";
-import { i18n } from "./locales/i18n";
+import { createApp } from "vue"
+import { createPinia } from "pinia"
+import { authenticationGuard } from "@/shared/authentication/authentication-guard"
+import App from "./App.vue"
+import { router } from "./router"
+import { i18n } from "./locales/i18n"
 
-import "@/assets/base.css";
+import "@/assets/base.css"
 
-const app = createApp(App);
+const app = createApp(App)
 
-app.use(createPinia());
-app.use(router);
-app.use(i18n);
+app.use(createPinia())
+app.use(router)
+app.use(i18n)
 
-authenticationGuard(router);
+authenticationGuard(router)
 
-app.mount("#app");
+app.mount("#app")
 ```
 
 ### メッセージの取得 {#getting-messages}
@@ -146,12 +122,12 @@ app.mount("#app");
 
 ```ts title="メッセージ利用例"
 <script setup lang="ts">
-import { i18n } from '@/locales/i18n';
+import { i18n } from '@/locales/i18n'
 
 const { t } = i18n.global;
 
 // TypeScript 上で利用する場合
-showToast(t('errorOccurred'));
+showToast(t('errorOccurred'))
 
 </script>
 

--- a/documents/contents/guidebooks/how-to-develop/vue-js/mock-mode-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/mock-mode-settings.md
@@ -89,14 +89,14 @@ npx msw init ./public --save
 
 ワークスペース直下に`mock`フォルダーを作成し、`mock`フォルダーの配下に`browser.ts`を作成します。
 
-```ts title="browser.ts"
+```typescript title="browser.ts"
 https://github.com/AlesInfiny/maia/blob/main/samples/web-csr/dressca-frontend/consumer/mock/browser.ts
 ```
 
 `mock`フォルダーの配下に、`handlers`フォルダーを作成し、さらにその配下に`index.ts`を作成します。
 ハンドラーの実装は別途行うため、現時点では空で構いません。
 
-```ts title="index.ts"
+```typescript title="index.ts"
 export const handlers = [] // 後で実装します。
 ```
 
@@ -104,7 +104,7 @@ export const handlers = [] // 後で実装します。
 モックモードで起動した場合にワーカーを立ち上げるように設定します。
 `main.ts`に以下のように設定してください。
 
-```ts title="main.ts"
+```typescript title="main.ts"
 async function enableMocking(): Promise<ServiceWorkerRegistration | undefined> {
   const { worker } = await import('../mock/browser') // モックモード以外ではインポート不要なので、動的にインポートします。
   return worker.start({

--- a/documents/contents/guidebooks/how-to-develop/vue-js/mock-mode-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/mock-mode-settings.md
@@ -90,17 +90,14 @@ npx msw init ./public --save
 ワークスペース直下に`mock`フォルダーを作成し、`mock`フォルダーの配下に`browser.ts`を作成します。
 
 ```ts title="browser.ts"
-import { setupWorker } from 'msw/browser';
-import { handlers } from './handlers';
-
-export const worker = setupWorker(...handlers);
+https://github.com/AlesInfiny/maia/blob/main/samples/web-csr/dressca-frontend/consumer/mock/browser.ts
 ```
 
 `mock`フォルダーの配下に、`handlers`フォルダーを作成し、さらにその配下に`index.ts`を作成します。
 ハンドラーの実装は別途行うため、現時点では空で構いません。
 
 ```ts title="index.ts"
-export const handlers = []; // 後で実装します。
+export const handlers = [] // 後で実装します。
 ```
 
 アプリケーションのエントリーポイントで、
@@ -109,7 +106,7 @@ export const handlers = []; // 後で実装します。
 
 ```ts title="main.ts"
 async function enableMocking(): Promise<ServiceWorkerRegistration | undefined> {
-  const { worker } = await import('../mock/browser'); // モックモード以外ではインポート不要なので、動的にインポートします。
+  const { worker } = await import('../mock/browser') // モックモード以外ではインポート不要なので、動的にインポートします。
   return worker.start({
     onUnhandledRequest: 'bypass', // MSW のハンドラーを未設定のリクエストに対して警告を出さないように設定します。
   });
@@ -117,9 +114,9 @@ async function enableMocking(): Promise<ServiceWorkerRegistration | undefined> {
 
 if (import.meta.env.MODE === 'mock') {
   try {
-    await enableMocking(); // ワーカーの起動を待ちます。
+    await enableMocking()
   } catch (error) {
-    console.error('モック用のワーカープロセスの起動に失敗しました。', error);
+    console.error('モック用のワーカープロセスの起動に失敗しました。', error)
   }
 }
 

--- a/documents/contents/guidebooks/how-to-develop/vue-js/mock-mode-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/mock-mode-settings.md
@@ -109,7 +109,7 @@ async function enableMocking(): Promise<ServiceWorkerRegistration | undefined> {
   const { worker } = await import('../mock/browser') // モックモード以外ではインポート不要なので、動的にインポートします。
   return worker.start({
     onUnhandledRequest: 'bypass', // MSW のハンドラーを未設定のリクエストに対して警告を出さないように設定します。
-  });
+  })
 }
 
 if (import.meta.env.MODE === 'mock') {
@@ -121,7 +121,7 @@ if (import.meta.env.MODE === 'mock') {
 }
 
 // ワーカーが起動したら、アプリケーションを立ち上げます。
-const app = createApp(App);
+const app = createApp(App)
 ```
 
 ??? info "ワーカープロセスの起動を待つ理由"

--- a/documents/contents/guidebooks/how-to-develop/vue-js/project-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/project-settings.md
@@ -117,7 +117,7 @@ Project Reference 機能については [Project References :material-open-in-ne
 
 ??? example "vite.config.ts の設定例"
 
-    ``` ts title="サンプルアプリケーションの vite.config.ts"
+    ```typescript title="サンプルアプリケーションの vite.config.ts"
     https://github.com/AlesInfiny/maia/blob/main/samples/web-csr/dressca-frontend/consumer/vite.config.ts
     ```
 
@@ -125,7 +125,7 @@ Project Reference 機能については [Project References :material-open-in-ne
 
     コマンドやモードに応じて異なる設定を適用する場合、関数を export して設定します。
 
-    ``` ts title="vite.config.ts" hl_lines="6"
+    ```typescript title="vite.config.ts" hl_lines="6"
     export default defineConfig(({ command, mode, isSsrBuild, isPreview }) => {
       if (command === 'serve') {
         return {
@@ -140,7 +140,7 @@ Project Reference 機能については [Project References :material-open-in-ne
     ??? example "条件付き設定の実装例"
         設定例では prod モードでビルド[^3]した際に、 Mock Service Worker のワーカースクリプトを削除するプラグインを読み込んでいます。
 
-        ``` ts title="サンプルアプリケーションの vite.config.ts (抜粋)" hl_lines="6"
+        ```typescript title="サンプルアプリケーションの vite.config.ts (抜粋)" hl_lines="6"
         https://github.com/AlesInfiny/maia/blob/main/samples/web-csr/dressca-frontend/consumer/vite.config.ts#L30-L35
         ```
 
@@ -150,7 +150,7 @@ Project Reference 機能については [Project References :material-open-in-ne
 
     ??? example "vitest.config.ts の実装例"
 
-        ``` ts title="サンプルアプリケーションの vitest.config.ts"
+        ```typescript title="サンプルアプリケーションの vitest.config.ts"
         https://github.com/AlesInfiny/maia/blob/main/samples/web-csr/dressca-frontend/consumer/vitest.config.ts
         ```
 
@@ -196,7 +196,7 @@ Project Reference 機能については [Project References :material-open-in-ne
 
         AlesInfiny Maia サンプルアプリでは、 バックエンドアプリとの API 通信のための OpenAPI や Axios の共通設定は `src/api-client/index.ts` で実装しています。以下の部分で `baseURL` を設定すると、 `dev` モードでビルドした際に `vite.config.ts` の `server.proxy` で設定した通りにパスの書換えができなくなります。そのため、 `dev` モードでは環境変数に空文字を設定して `basePath` `baseURL` に値を設定しないようにする、といった工夫が必要です。
 
-        ``` ts title="サンプルアプリケーションの src/api-client/index.ts (抜粋)" hl_lines="2"
+        ```typescript title="サンプルアプリケーションの src/api-client/index.ts (抜粋)" hl_lines="2"
         https://github.com/AlesInfiny/maia/blob/main/samples/web-csr/dressca-frontend/consumer/src/api-client/index.ts#L18-L19
         ```
 

--- a/documents/contents/samples/azure-ad-b2c/azure-ad-b2c-consideration.md
+++ b/documents/contents/samples/azure-ad-b2c/azure-ad-b2c-consideration.md
@@ -19,7 +19,7 @@ MSAL.js で提供されている  `loginPopup()` や `loginRedirect()` といっ
 MSAL のインスタンス化に使用する構成オブジェクトをもとに、キャッシュストレージの保存先を設定できます。
 本サンプルでは、 `src/services/authentication/authentication-config.ts` の以下の部分で設定します。
 
-``` ts title="authentication-config.ts" hl_lines="9"
+```typescript title="authentication-config.ts" hl_lines="9"
 export const msalConfig = {
   auth: {
     clientId: import.meta.env.VITE_ADB2C_APP_CLIENT_ID,

--- a/samples/azure-ad-b2c-sample/README.md
+++ b/samples/azure-ad-b2c-sample/README.md
@@ -322,7 +322,7 @@ Azure AD B2C に追加したユーザーは、以下の手順で削除できま�
 1. `auth-frontend\.env.dev` に記述した Azure AD B2C の設定をフロントエンドアプリケーションの `.env.dev` にコピーします。
 1. `env.d.ts` のインターフェースに、前の手順で `.env.dev` に追加したプロパティを追加します。
 
-    ```ts
+    ```typescript
     interface ImportMetaEnv {
       // 認証に関係のないプロパティは省略
       readonly VITE_ADB2C_USER_FLOW_SIGN_IN: string;
@@ -342,7 +342,7 @@ Azure AD B2C に追加したユーザーは、以下の手順で削除できま�
 1. 認証が成功したら、認証が必要な Web API リクエストヘッダーに Bearer トークンを付与する必要があります。
     AlesInfiny Maia のサンプルアプリケーション Dressca の場合、 `src\api-client\index.ts` を編集します。
 
-    ```ts
+    ```typescript
     import axios from "axios";
     import * as apiClient from "@/generated/api-client";
     import { authenticationService } from '@/services/authentication/authentication-service';
@@ -392,7 +392,7 @@ Azure AD B2C に追加したユーザーは、以下の手順で削除できま�
 
 1. `ログイン` 画面へのリンクを含む Vue ファイルの `<script>` セクションにコードを追加します。
 
-    ```ts
+    ```vue
     <script setup lang="ts">
     import { authenticationService } from '@/services/authentication/authentication-service';
     import { useAuthenticationStore } from '@/stores/authentication/authentication';
@@ -406,7 +406,7 @@ Azure AD B2C に追加したユーザーは、以下の手順で削除できま�
 
 1. `ログイン` 画面へのリンクを以下のように記述します（クリック時に `signIn` メソッドが動作すれば `button` である必要はありません）。
 
-    ```html
+    ```vue
     <button v-if="!authenticationStore.isAuthenticated" @click="signIn()">ログイン</button>
     ```
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

Prettier の設定変更に合わせて、TypeScriptのコード例の文末セミコロンを削除しました。
修正対象ページのうち、サンプルアプリの例をそのままあるいは抜粋して掲載しているものなど、スニペットのリンクに置き換えて問題ないものは置き換えました。

## この Pull request では実施していないこと

静的コード分析とフォーマット については、下記のPRで変更します。
- https://github.com/AlesInfiny/maia/pull/2754

プロジェクトの共通設定 については、下記の issue で対応します。
- https://github.com/AlesInfiny/maia/issues/2835

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->