### PR TITLE
CI で使用する Node.js のバージョンを LTS バージョンに固定する

### DIFF
--- a/.github/workflows/lint-documents/action.yml
+++ b/.github/workflows/lint-documents/action.yml
@@ -7,7 +7,8 @@ runs:
     - name: Node.js のセットアップ
       uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: lts/*
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     - name: npm パッケージのインストール
       shell: bash

--- a/.github/workflows/samples-azure-ad-b2c-ci.yml
+++ b/.github/workflows/samples-azure-ad-b2c-ci.yml
@@ -21,22 +21,19 @@ jobs:
       contents: read
     env:
       NO_COLOR: "1"  # 文字化け防止のためカラーコードを出力しない
-    strategy:
-      matrix:
-        node-version: [20.x]
     defaults:
       run:
         working-directory: ${{ env.FRONTEND_WORKING_DIRECTORY }}
-
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js LTS
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: lts/*
+          # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
       - uses: actions/cache@v4
         id: node_modules_cache_id

--- a/.github/workflows/samples-dressca-admin-frontend.ci.yml
+++ b/.github/workflows/samples-dressca-admin-frontend.ci.yml
@@ -24,17 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NO_COLOR: "1"  # 文字化け防止のためカラーコードを出力しない
-    strategy:
-      matrix:
-        node-version: [20.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
       - uses: actions/checkout@v5
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js LTS
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: lts/*
+          # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
       - uses: actions/cache@v4
         id: node_modules_cache_id

--- a/.github/workflows/samples-dressca-consumer-frontend.ci.yml
+++ b/.github/workflows/samples-dressca-consumer-frontend.ci.yml
@@ -26,17 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NO_COLOR: "1"  # 文字化け防止のためカラーコードを出力しない
-    strategy:
-      matrix:
-        node-version: [20.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
       - uses: actions/checkout@v5
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js LTS
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: lts/*
+          # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
       - uses: actions/cache@v4
         id: node_modules_cache_id


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

各 CI ワークフローで使用する Node.js のバージョンを LTS バージョンに固定しました。
strategy と matrix の指定により特に複数パターンでの実行を行っていないことを検知したため、不要な設定を削除しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク
下記のドキュメントに記載の通り、 LTS バージョンを指定するエイリアスが利用できます。
https://github.com/actions/setup-node?tab=readme-ov-file#supported-version-syntax

<!-- I want to review in Japanese. -->