### PR TITLE
textlint の検査対象からサンプルの .gradle 配下を除外

### DIFF
--- a/.textlintignore
+++ b/.textlintignore
@@ -7,3 +7,6 @@ samples/**/spotbugs*.txt
 # third-party-licenses フォルダーはコピーしたファイルを配置するため、テスト対象から除外
 third-party-licenses/**
 
+# samples 配下の gradle 関連の txt ファイルを除外
+samples/**/.gradle/*.txt
+

--- a/.textlintignore
+++ b/.textlintignore
@@ -2,7 +2,7 @@
 samples/**/spotbugs*.txt
 
 # samples 配下の gradle 関連の txt ファイルを除外
-samples/**/.gradle/*.txt
+samples/**/.gradle/**
 
 # openapi-generator で自動生成されるファイルをテスト対象から除外
 **/src/generated/api-client/docs/*.md

--- a/.textlintignore
+++ b/.textlintignore
@@ -1,7 +1,7 @@
 # SpotBugsで自動生成されるテキストファイルをテスト対象から除外
 samples/**/spotbugs*.txt
 
-# samples 配下の gradle 関連の txt ファイルを除外
+# samples 配下の gradle 関連のキャッシュファイル・フォルダーを除外
 samples/**/.gradle/**
 
 # openapi-generator で自動生成されるファイルをテスト対象から除外

--- a/.textlintignore
+++ b/.textlintignore
@@ -1,12 +1,12 @@
 # SpotBugsで自動生成されるテキストファイルをテスト対象から除外
 samples/**/spotbugs*.txt
 
+# samples 配下の gradle 関連の txt ファイルを除外
+samples/**/.gradle/*.txt
+
 # openapi-generator で自動生成されるファイルをテスト対象から除外
 **/src/generated/api-client/docs/*.md
 
 # third-party-licenses フォルダーはコピーしたファイルを配置するため、テスト対象から除外
 third-party-licenses/**
-
-# samples 配下の gradle 関連の txt ファイルを除外
-samples/**/.gradle/*.txt
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

textlintignore にサンプルの .gradle 配下にあるテキストファイルを除外するような設定を追加しました。

## この Pull request では実施していないこと

なし。

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #2911 

<!-- I want to review in Japanese. -->