### PR TITLE
dependabot について npm (dressca) と npm (auth-frontend) の PR 作成上限数を増やす

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,7 +45,7 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 20
+    open-pull-requests-limit: 60
     commit-message:
       prefix: "npm-dressca-frontend"
     labels:
@@ -74,7 +74,7 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 20
+    open-pull-requests-limit: 40
     commit-message:
       prefix: "npm-auth-frontend"
     labels:


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

dependabot について、上限によく引っかかる npm (dressca) と npm (auth-frontend) の PR 作成上限数を増やしました。
上限値は package.json のパッケージ数 + package-lock.json 単独への PR を想定し、
10 程度のバッファを設けたキリの良い数字としています。　

## Issues や Discussions 、関連する Web サイトなどへのリンク
なし

<!-- I want to review in Japanese. -->