### PR TITLE
[Dressca]不要な Tailwind ユーティリティの記述を削除する

### DIFF
--- a/samples/web-csr/dressca-frontend/consumer/src/components/basket/BasketItem.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/components/basket/BasketItem.vue
@@ -51,7 +51,7 @@ const remove = () => {
       <img
         :src="getFirstAssetUrl(item.catalogItem?.assetCodes)"
         :alt="item.catalogItem?.name"
-        class="pointer-events-none h-[150px]"
+        class="pointer-events-none h-40"
       />
       <div class="ml-2">
         <p>{{ item.catalogItem?.name }}</p>

--- a/samples/web-csr/dressca-frontend/consumer/src/views/basket/BasketView.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/basket/BasketView.vue
@@ -151,11 +151,11 @@ onUnmounted(() => basketStore.deleteAddedItemId())
         <span class="text-lg font-medium text-green-500">
           {{ t('addedItemsToBasket') }}
         </span>
-        <div class="mt-4 flex grid grid-cols-1 items-center lg:grid-cols-3">
+        <div class="mt-4 grid grid-cols-1 items-center lg:grid-cols-3">
           <img
             :src="getFirstAssetUrl(getAddedItem.catalogItem?.assetCodes)"
             :alt="getAddedItem.catalogItem?.name"
-            class="pointer-events-none m-auto h-[150px]"
+            class="pointer-events-none m-auto h-40"
           />
           <span class="text-center lg:text-left">
             {{ getAddedItem.catalogItem?.name }}
@@ -173,14 +173,14 @@ onUnmounted(() => basketStore.deleteAddedItemId())
       </div>
       <div v-if="!isEmpty()" class="mx-2 mt-8">
         <span class="text-2xl font-medium">現在のカートの中身</span>
-        <div class="mt-4 flex hidden grid-cols-1 items-center lg:grid lg:grid-cols-5">
+        <div class="mt-4 hidden grid-cols-1 items-center lg:grid lg:grid-cols-5">
           <div class="text-center text-lg font-medium lg:col-span-3">商品</div>
           <div class="text-right text-lg font-medium lg:col-span-1">数量</div>
         </div>
         <div
           v-for="item in getBasket.basketItems"
           :key="item.catalogItemId"
-          class="mt-4 flex grid grid-cols-5 items-center lg:grid-cols-8"
+          class="mt-4 grid grid-cols-5 items-center lg:grid-cols-8"
           :class="{
             'bg-red-100': getDeletedItemIds.includes(item.catalogItemId),
           }"

--- a/samples/web-csr/dressca-frontend/consumer/src/views/catalog/CatalogView.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/catalog/CatalogView.vue
@@ -110,7 +110,7 @@ watch([selectedCategory, selectedBrand], async () => {
             <img
               :src="getAssetUrl(item.assetCode)"
               alt="Special Contents"
-              class="pointer-events-none m-auto max-h-[350px] min-w-0"
+              class="pointer-events-none m-auto max-h-90 min-w-0"
             />
           </template>
         </CarouselSlider>

--- a/samples/web-csr/dressca-frontend/consumer/src/views/ordering/CheckoutView.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/ordering/CheckoutView.vue
@@ -77,7 +77,7 @@ onMounted(async () => {
     </span>
   </div>
   <div class="container mx-auto my-4 max-w-4xl">
-    <div class="mx-2 flex grid grid-cols-2 items-center lg:grid-cols-3 lg:gap-x-12">
+    <div class="mx-2 grid grid-cols-2 items-center lg:grid-cols-3 lg:gap-x-12">
       <table
         class="mt-2 table-fixed border-t border-b lg:col-span-1 lg:row-start-1 lg:mt-0 lg:border"
       >
@@ -140,14 +140,14 @@ onMounted(async () => {
       <div
         v-for="item in getBasket.basketItems"
         :key="item.catalogItemId"
-        class="mt-4 flex grid grid-cols-5 items-center lg:grid-cols-8"
+        class="mt-4 grid grid-cols-5 items-center lg:grid-cols-8"
       >
         <div class="col-span-4 lg:col-span-5">
           <div class="grid grid-cols-2">
             <img
               :src="getFirstAssetUrl(item.catalogItem?.assetCodes)"
               :alt="item.catalogItem?.name"
-              class="pointer-events-none h-[150px]"
+              class="pointer-events-none h-40"
             />
             <div class="ml-2">
               <p>{{ item.catalogItem?.name }}</p>

--- a/samples/web-csr/dressca-frontend/consumer/src/views/ordering/DoneView.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/ordering/DoneView.vue
@@ -74,7 +74,7 @@ onMounted(async () => {
       </span>
     </div>
     <div class="container mx-auto my-4 max-w-4xl">
-      <div class="mx-2 flex grid grid-cols-1 items-center lg:grid-cols-3 lg:gap-x-12">
+      <div class="mx-2 grid grid-cols-1 items-center lg:grid-cols-3 lg:gap-x-12">
         <table
           class="mt-2 table-fixed border-t border-b lg:col-span-1 lg:row-start-1 lg:mt-0 lg:border"
         >
@@ -130,14 +130,14 @@ onMounted(async () => {
         <div
           v-for="item in lastOrdered?.orderItems"
           :key="item.itemOrdered?.id"
-          class="mt-4 flex grid grid-cols-5 items-center lg:grid-cols-8"
+          class="mt-4 grid grid-cols-5 items-center lg:grid-cols-8"
         >
           <div class="col-span-4 lg:col-span-5">
             <div class="grid grid-cols-2">
               <img
                 :src="getFirstAssetUrl(item.itemOrdered?.assetCodes)"
                 :alt="item.itemOrdered?.name"
-                class="pointer-events-none h-[150px]"
+                class="pointer-events-none h-40"
               />
               <div class="ml-2">
                 <p>{{ item.itemOrdered?.name }}</p>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

- VS Code の拡張機能で警告が表示される、不要な Tailwind ユーティリティの記述を削除しました。
    - cssConflict(同じプロパティに値を何度も設定している)が表示されます。
    - 挙動としては後勝ちになるので既存の表示と同じになるように前側（左側）を削除しました。
    - https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss
    
- tailwind CSS v4 への移行時の対応漏れに対応しました。 px べた書きのものについて近しい 4 の倍数で置き換えました。
    - 4 の倍数以外の px 表記をスタイリング上使用したい場合は、べた書きせずにTailwindの設定を拡張するほうがベターなのですが、Dressca でこだわる理由はないと判断して近い値にしました。
    - 影響として、カルーセルの画像と買い物籠のアイテムの画像がわずかに大きく表示されるようになりました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし
<!-- I want to review in Japanese. -->