### PR TITLE
モノレポのルートプロジェクト直下のファイルをCIのフォーマット対象にする

### DIFF
--- a/.github/workflows/samples-azure-ad-b2c-ci.yml
+++ b/.github/workflows/samples-azure-ad-b2c-ci.yml
@@ -49,7 +49,9 @@ jobs:
       - name: node パッケージのインストール
         if: ${{ steps.node_modules_cache_id.outputs.cache-hit != 'true' }}
         run: npm ci
-
+      - id: run-format-root
+        name: ルート直下の format の実行
+        run: npm run format:ci:root >> /var/tmp/format-root-result.txt 2>&1
       - id: run-lint
         name: lintの実行
         run: npm run lint:ci:app >> /var/tmp/lint-result.txt 2>&1
@@ -65,6 +67,13 @@ jobs:
       - id: run-unit-tests
         name: 単体テストの実行
         run: npm run test:unit:app >> /var/tmp/unit-test-result.txt 2>&1
+
+      - name: formatの結果出力
+        if: ${{ success() || (failure() && steps.run-format-root.conclusion == 'failure') }}
+        uses: ./.github/workflows/file-to-summary
+        with:
+          body: /var/tmp/format-root-result.txt
+          header: 'formatの結果 :pen:'
 
       - name: lintの結果出力
         if: ${{ success() || (failure() && steps.run-lint.conclusion == 'failure') }}

--- a/.github/workflows/samples-dressca-root-frontend-ci.yml
+++ b/.github/workflows/samples-dressca-root-frontend-ci.yml
@@ -10,7 +10,6 @@ on:
     branches: [main]
     paths:
       - 'samples/web-csr/dressca-frontend/*.*'
-      - '!samples/web-csr/dressca-frontend/package-lock.json'
       - '.github/workflows/samples-dressca-root-frontend-ci.yml'
   workflow_dispatch:
 

--- a/.github/workflows/samples-dressca-root-frontend-ci.yml
+++ b/.github/workflows/samples-dressca-root-frontend-ci.yml
@@ -1,0 +1,59 @@
+---
+
+name: dressca-root-frontend CI
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'samples/web-csr/dressca-frontend/*.*'
+      - '!samples/web-csr/dressca-frontend/package-lock.json'
+      - '.github/workflows/samples-dressca-root-frontend-ci.yml'
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: samples/web-csr/dressca-frontend/
+
+jobs:
+  check:
+    name: Dressca モノレポのルートプロジェクトのチェック
+    runs-on: ubuntu-latest
+    env:
+      NO_COLOR: "1"  # 文字化け防止のためカラーコードを出力しない
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v5
+      - name: Use Node.js LTS
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8  # v4
+        with:
+          node-version: lts/*
+          # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4
+        id: node_modules_cache_id
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-check-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
+      - name: node パッケージのキャッシュ確認
+        run: echo '${{ toJSON(steps.node_modules_cache_id.outputs) }}'
+
+      - name: node パッケージのインストール
+        if: ${{ steps.node_modules_cache_id.outputs.cache-hit != 'true' }}
+        run: npm ci
+
+      - id: run-format
+        name: format の実行
+        run: npm run format:ci:root >> /var/tmp/format-result.txt 2>&1
+
+      - name: format の結果出力
+        if: ${{ success() || (failure() && steps.run-format.conclusion == 'failure') }}
+        uses: ./.github/workflows/file-to-summary
+        with:
+          body: /var/tmp/format-result.txt
+          header: 'format の結果 :pen:'

--- a/samples/azure-ad-b2c-sample/auth-frontend/package.json
+++ b/samples/azure-ad-b2c-sample/auth-frontend/package.json
@@ -4,6 +4,8 @@
   "type": "module",
   "private": "true",
   "scripts": {
+    "format:root": "prettier --write ./*.{js,ts,json,yaml}",
+    "format:ci:root": "prettier --check ./*.{js,ts,json,yaml}",
     "lint:ci:app": "npm run lint:ci -w app",
     "type-check:app": "npm run type-check -w app",
     "build-only:dev:app": "npm run build-only:dev -w app",

--- a/samples/web-csr/dressca-frontend/.prettierrc.js
+++ b/samples/web-csr/dressca-frontend/.prettierrc.js
@@ -3,10 +3,10 @@
  * @type {import("prettier").Config}
  */
 const config = {
-  "$schema": "https://json.schemastore.org/prettierrc",
-  "semi": false,
-  "singleQuote": true,
-  "printWidth": 100
+  $schema: 'https://json.schemastore.org/prettierrc',
+  semi: false,
+  singleQuote: true,
+  printWidth: 100,
 }
 
-export default config;
+export default config

--- a/samples/web-csr/dressca-frontend/package.json
+++ b/samples/web-csr/dressca-frontend/package.json
@@ -4,6 +4,8 @@
   "type": "module",
   "private": "true",
   "scripts": {
+    "format:root": "prettier --write ./*.{js,ts,json,yaml}",
+    "format:ci:root": "prettier --check './*.{js,ts,json,yaml}",
     "lint:ci:consumer": "npm run lint:ci -w consumer",
     "type-check:consumer": "npm run type-check -w consumer",
     "build-only:dev:consumer": "npm run build-only:dev -w consumer",

--- a/samples/web-csr/dressca-frontend/package.json
+++ b/samples/web-csr/dressca-frontend/package.json
@@ -5,7 +5,7 @@
   "private": "true",
   "scripts": {
     "format:root": "prettier --write ./*.{js,ts,json,yaml}",
-    "format:ci:root": "prettier --check './*.{js,ts,json,yaml}",
+    "format:ci:root": "prettier --check ./*.{js,ts,json,yaml}",
     "lint:ci:consumer": "npm run lint:ci -w consumer",
     "type-check:consumer": "npm run type-check -w consumer",
     "build-only:dev:consumer": "npm run build-only:dev -w consumer",


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

- Dressca と AzureADB2CAuth について、モノレポのルートプロジェクト直下のファイルをPrettierでフォーマットするように修正しました。

- Dressca については、無駄な実行を減らすためにルートプロジェクト用のワークフローファイルを新規作成しました。
>https://github.com/AlesInfiny/maia/actions/runs/18010931049/job/51243129035?pr=3096

- AzureADB2CAuth については、ワークフローを1ファイルにまとめることを優先し、既存のCI処理に含めました。

## この Pull request では実施していないこと

- lint 、type-check 、build はルートプロジェクトに対して実行するうまみがほとんどないので実行していません。

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->