### PR TITLE
 カスタムエラーハンドラーのコールバック関数で非同期処理を受け入れ可能にする

### DIFF
--- a/samples/azure-ad-b2c-sample/auth-frontend/app/src/App.vue
+++ b/samples/azure-ad-b2c-sample/auth-frontend/app/src/App.vue
@@ -29,12 +29,12 @@ const signIn = async () => {
     // ポップアップ画面をユーザーが×ボタンで閉じると、 BrowserAuthError が発生します。
     if (error instanceof BrowserAuthError) {
       // 認証途中でポップアップを閉じることはよくあるユースケースなので、ユーザーには特に通知しません。
-      customErrorHandler.handle(error, () => {
+      await customErrorHandler.handleAsync(error, () => {
         console.info('ユーザーが認証処理を中断しました。')
         authenticationStore.updateAuthenticated(false)
       })
     } else {
-      customErrorHandler.handle(error, () => {
+      await customErrorHandler.handleAsync(error, () => {
         window.alert('AzureADB2C での認証に失敗しました。')
       })
     }
@@ -43,7 +43,7 @@ const signIn = async () => {
   try {
     await fetchUser()
   } catch (error) {
-    customErrorHandler.handle(error, () => {
+    await customErrorHandler.handleAsync(error, () => {
       window.alert('ユーザー情報の取得に失敗しました。')
     })
   }
@@ -53,7 +53,7 @@ async function updateServerTime() {
   try {
     await fetchServerTime()
   } catch (error) {
-    customErrorHandler.handle(error, () => {
+    await customErrorHandler.handleAsync(error, () => {
       window.alert('サーバー時刻の更新に失敗しました。')
     })
   }
@@ -63,14 +63,14 @@ onMounted(async () => {
   try {
     await fetchServerTime()
   } catch (error) {
-    customErrorHandler.handle(error, () => {
+    await customErrorHandler.handleAsync(error, () => {
       window.alert('サーバー時刻の取得に失敗しました。')
     })
   }
   try {
     await fetchUser()
   } catch (error) {
-    customErrorHandler.handle(error, () => {
+    await customErrorHandler.handleAsync(error, () => {
       window.alert('ユーザー情報の取得に失敗しました。')
     })
   }

--- a/samples/azure-ad-b2c-sample/auth-frontend/app/src/App.vue
+++ b/samples/azure-ad-b2c-sample/auth-frontend/app/src/App.vue
@@ -20,7 +20,7 @@ const serverTimeStore = useServerTimeStore()
 const { getServerTime } = storeToRefs(serverTimeStore)
 const authenticationStore = useAuthenticationStore()
 const { isAuthenticated } = storeToRefs(authenticationStore)
-const customErrorHandler = useCustomErrorHandler()
+const handleErrorAsync = useCustomErrorHandler()
 
 const signIn = async () => {
   try {
@@ -29,12 +29,12 @@ const signIn = async () => {
     // ポップアップ画面をユーザーが×ボタンで閉じると、 BrowserAuthError が発生します。
     if (error instanceof BrowserAuthError) {
       // 認証途中でポップアップを閉じることはよくあるユースケースなので、ユーザーには特に通知しません。
-      await customErrorHandler.handleAsync(error, () => {
+      await handleErrorAsync(error, () => {
         console.info('ユーザーが認証処理を中断しました。')
         authenticationStore.updateAuthenticated(false)
       })
     } else {
-      await customErrorHandler.handleAsync(error, () => {
+      await handleErrorAsync(error, () => {
         window.alert('AzureADB2C での認証に失敗しました。')
       })
     }
@@ -43,7 +43,7 @@ const signIn = async () => {
   try {
     await fetchUser()
   } catch (error) {
-    await customErrorHandler.handleAsync(error, () => {
+    await handleErrorAsync(error, () => {
       window.alert('ユーザー情報の取得に失敗しました。')
     })
   }
@@ -53,7 +53,7 @@ async function updateServerTime() {
   try {
     await fetchServerTime()
   } catch (error) {
-    await customErrorHandler.handleAsync(error, () => {
+    await handleErrorAsync(error, () => {
       window.alert('サーバー時刻の更新に失敗しました。')
     })
   }
@@ -63,14 +63,14 @@ onMounted(async () => {
   try {
     await fetchServerTime()
   } catch (error) {
-    await customErrorHandler.handleAsync(error, () => {
+    await handleErrorAsync(error, () => {
       window.alert('サーバー時刻の取得に失敗しました。')
     })
   }
   try {
     await fetchUser()
   } catch (error) {
-    await customErrorHandler.handleAsync(error, () => {
+    await handleErrorAsync(error, () => {
       window.alert('ユーザー情報の取得に失敗しました。')
     })
   }

--- a/samples/azure-ad-b2c-sample/auth-frontend/app/src/shared/error-handler/custom-error-handler.ts
+++ b/samples/azure-ad-b2c-sample/auth-frontend/app/src/shared/error-handler/custom-error-handler.ts
@@ -7,7 +7,8 @@ import { formatError } from '@/shared/helpers/format-error'
 import type { MaybeAsyncFunction, MaybePromise } from '@/types'
 
 /**
- * カスタムエラーハンドラーのインターフェースです。
+ * エラーを受け取り、呼び出し側の後処理（callback）および
+ * エラー種別ごとの追加処理を順に実行する非同期ハンドラー関数の型です。
  */
 export type handleErrorAsyncFunction = (
   error: unknown,
@@ -19,7 +20,7 @@ export type handleErrorAsyncFunction = (
 
 /**
  * カスタムエラーハンドラーを取得します。
- * @returns カスタムエラーハンドラー。
+ * @returns handleErrorAsyncFunction 型の関数。
  */
 export function useCustomErrorHandler(): handleErrorAsyncFunction {
   const handleErrorAsync = async (

--- a/samples/azure-ad-b2c-sample/auth-frontend/app/src/types/index.ts
+++ b/samples/azure-ad-b2c-sample/auth-frontend/app/src/types/index.ts
@@ -1,0 +1,2 @@
+export type MaybePromise<T> = T | Promise<T>
+export type MaybeAsyncFunction<R> = () => MaybePromise<R>

--- a/samples/azure-ad-b2c-sample/auth-frontend/app/src/types/index.ts
+++ b/samples/azure-ad-b2c-sample/auth-frontend/app/src/types/index.ts
@@ -1,2 +1,16 @@
+/**
+ * 同期値または Promise にラップされた非同期値を表すユーティリティ型です。
+ *
+ * @typeParam T - 値の型。
+ *
+ */
 export type MaybePromise<T> = T | Promise<T>
+
+/**
+ * 引数なしの関数で、戻り値が同期/非同期のどちらでもよい関数を表すユーティリティ型です。
+ *
+ * @typeParam R - 解決後の戻り値の型。
+ * @returns 同期値 `R` もしくは `Promise<R>`。
+ * @see MaybePromise
+ */
 export type MaybeAsyncFunction<R> = () => MaybePromise<R>

--- a/samples/web-csr/dressca-frontend/admin/src/shared/error-handler/custom-error-handler.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/shared/error-handler/custom-error-handler.ts
@@ -1,71 +1,69 @@
 import { useEventBus } from '@vueuse/core'
 import { CustomErrorBase, UnauthorizedError, NetworkError, ServerError } from './custom-error'
 import { unauthorizedErrorEventKey, unhandledErrorEventKey } from '../events'
+import type { MaybeAsyncFunction, MaybePromise } from '@/types'
 
 /**
- * カスタムエラーハンドラーを型付けするためのインターフェースです。
+ * エラーを受け取り、呼び出し側の後処理（callback）および
+ * エラー種別ごとの追加処理を順に実行する非同期ハンドラー関数の型です。
  */
-export interface CustomErrorHandler {
-  handle(
-    error: unknown,
-    callback: () => void,
-    handlingUnauthorizedError?: (() => void) | null,
-    handlingNetworkError?: (() => void) | null,
-    handlingServerError?: (() => void) | null,
-  ): void
-}
+export type handleErrorAsyncFunction = (
+  error: unknown,
+  callback: MaybeAsyncFunction<void>,
+  handlingUnauthorizedError?: MaybeAsyncFunction<void> | null,
+  handlingNetworkError?: MaybeAsyncFunction<void> | null,
+  handlingServerError?: MaybeAsyncFunction<void> | null,
+) => MaybePromise<void>
 
 /**
  * カスタムエラーハンドラーを取得します。
- * @returns カスタムエラーハンドラー。
+ * @returns handleErrorAsyncFunction 型の関数。
  */
-export function useCustomErrorHandler(): CustomErrorHandler {
-  const customErrorHandler: CustomErrorHandler = {
-    handle: (
-      error: unknown,
-      callback: () => void,
-      handlingUnauthorizedError: (() => void) | null = null,
-      handlingNetworkError: (() => void) | null = null,
-      handlingServerError: (() => void) | null = null,
-    ) => {
-      const unhandledErrorEventBus = useEventBus(unhandledErrorEventKey)
-      const unauthorizedErrorEventBus = useEventBus(unauthorizedErrorEventKey)
-      // ハンドリングできるエラーの場合はコールバックを実行します。
-      if (error instanceof CustomErrorBase) {
-        callback()
+export function useCustomErrorHandler(): handleErrorAsyncFunction {
+  const handleErrorAsync = async (
+    error: unknown,
+    callback: MaybeAsyncFunction<void>,
+    handlingUnauthorizedError: MaybeAsyncFunction<void> | null = null,
+    handlingNetworkError: MaybeAsyncFunction<void> | null = null,
+    handlingServerError: MaybeAsyncFunction<void> | null = null,
+  ) => {
+    const unhandledErrorEventBus = useEventBus(unhandledErrorEventKey)
+    const unauthorizedErrorEventBus = useEventBus(unauthorizedErrorEventKey)
+    // ハンドリングできるエラーの場合はコールバックを実行します。
+    if (error instanceof CustomErrorBase) {
+      await callback()
 
-        // エラーの種類によって共通処理を行います。
-        // switch だと instanceof での判定ができないため if 文で判定します。
-        if (error instanceof UnauthorizedError) {
-          if (handlingUnauthorizedError) {
-            handlingUnauthorizedError()
-          } else {
-            unauthorizedErrorEventBus.emit({
-              details: 'ログインしてください。',
-            })
-          }
-        } else if (error instanceof NetworkError) {
-          if (handlingNetworkError) {
-            handlingNetworkError()
-          } else {
-            unhandledErrorEventBus.emit({
-              message: 'ネットワークエラーが発生しました。',
-            })
-          }
-        } else if (error instanceof ServerError) {
-          if (handlingServerError) {
-            handlingServerError()
-          } else {
-            unhandledErrorEventBus.emit({
-              message: 'サーバーエラーが発生しました。',
-            })
-          }
+      // エラーの種類によって共通処理を行います。
+      // switch だと instanceof での判定ができないため if 文で判定します。
+      if (error instanceof UnauthorizedError) {
+        if (handlingUnauthorizedError) {
+          await handlingUnauthorizedError()
+        } else {
+          unauthorizedErrorEventBus.emit({
+            details: 'ログインしてください。',
+          })
         }
-      } else {
-        // ハンドリングできないエラーの場合は上位にエラーを再スローします。
-        throw error
+      } else if (error instanceof NetworkError) {
+        if (handlingNetworkError) {
+          await handlingNetworkError()
+        } else {
+          unhandledErrorEventBus.emit({
+            message: 'ネットワークエラーが発生しました。',
+          })
+        }
+      } else if (error instanceof ServerError) {
+        if (handlingServerError) {
+          await handlingServerError()
+        } else {
+          unhandledErrorEventBus.emit({
+            message: 'サーバーエラーが発生しました。',
+          })
+        }
       }
-    },
+    } else {
+      // ハンドリングできないエラーの場合は上位にエラーを再スローします。
+      throw error
+    }
   }
-  return customErrorHandler
+  return handleErrorAsync
 }

--- a/samples/web-csr/dressca-frontend/admin/src/types/index.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/types/index.ts
@@ -1,0 +1,16 @@
+/**
+ * 同期値または Promise にラップされた非同期値を表すユーティリティ型です。
+ *
+ * @typeParam T - 値の型。
+ *
+ */
+export type MaybePromise<T> = T | Promise<T>
+
+/**
+ * 引数なしの関数で、戻り値が同期/非同期のどちらでもよい関数を表すユーティリティ型です。
+ *
+ * @typeParam R - 解決後の戻り値の型。
+ * @returns 同期値 `R` もしくは `Promise<R>`。
+ * @see MaybePromise
+ */
+export type MaybeAsyncFunction<R> = () => MaybePromise<R>

--- a/samples/web-csr/dressca-frontend/admin/src/views/authentication/LoginView.vue
+++ b/samples/web-csr/dressca-frontend/admin/src/views/authentication/LoginView.vue
@@ -16,7 +16,7 @@ const formSchema = yup.object({
 
 const router = useRouter()
 const route = useRoute()
-const customErrorHandler = useCustomErrorHandler()
+const handleErrorAsync = useCustomErrorHandler()
 
 const { meta } = useForm({ validationSchema: formSchema })
 const { value: userName, errorMessage: userNameError } = useField<string>('userName')
@@ -33,7 +33,7 @@ const login = async () => {
   try {
     await loginAsync()
   } catch (error) {
-    customErrorHandler.handle(error, () => {
+    await handleErrorAsync(error, () => {
       showToast('ログインに失敗しました。')
     })
   }

--- a/samples/web-csr/dressca-frontend/admin/src/views/catalog/ItemsAddView.vue
+++ b/samples/web-csr/dressca-frontend/admin/src/views/catalog/ItemsAddView.vue
@@ -14,7 +14,7 @@ import { LoadingSpinnerOverlay } from '@/components/common/LoadingSpinnerOverlay
 import { useCustomErrorHandler } from '@/shared/error-handler/custom-error-handler'
 
 const router = useRouter()
-const customErrorHandler = useCustomErrorHandler()
+const handleErrorAsync = useCustomErrorHandler()
 const authenticationStore = useAuthenticationStore()
 const { isInRole } = storeToRefs(authenticationStore)
 
@@ -83,7 +83,7 @@ const AddItem = async () => {
     )
     showAddNotice.value = true
   } catch (error) {
-    customErrorHandler.handle(error, () => {
+    await handleErrorAsync(error, () => {
       showToast('カタログアイテムの追加に失敗しました。')
     })
   }
@@ -109,7 +109,7 @@ onMounted(async () => {
   try {
     ;[catalogCategories.value, catalogBrands.value] = await fetchCategoriesAndBrands()
   } catch (error) {
-    customErrorHandler.handle(error, () => {
+    await handleErrorAsync(error, () => {
       showToast('カテゴリとブランド情報の取得に失敗しました。')
     })
   } finally {

--- a/samples/web-csr/dressca-frontend/admin/src/views/catalog/ItemsEditView.vue
+++ b/samples/web-csr/dressca-frontend/admin/src/views/catalog/ItemsEditView.vue
@@ -25,7 +25,7 @@ import { Roles } from '@/shared/constants/roles'
 import { LoadingSpinnerOverlay } from '@/components/common/LoadingSpinnerOverlay'
 import { useCustomErrorHandler } from '@/shared/error-handler/custom-error-handler'
 
-const customErrorHandler = useCustomErrorHandler()
+const handleErrorAsync = useCustomErrorHandler()
 const authenticationStore = useAuthenticationStore()
 const { isInRole } = storeToRefs(authenticationStore)
 const router = useRouter()
@@ -176,7 +176,7 @@ const getItem = async (itemId: number) => {
       showToast('対象のアイテムが見つかりませんでした。')
       router.push({ name: 'catalog/items' })
     }
-    customErrorHandler.handle(error, () => {
+    await handleErrorAsync(error, () => {
       showToast('アイテムの取得に失敗しました。')
     })
   }
@@ -189,7 +189,7 @@ const getCategoriesAndBrands = async () => {
   try {
     ;[catalogCategories.value, catalogBrands.value] = await fetchCategoriesAndBrands()
   } catch (error) {
-    customErrorHandler.handle(error, () => {
+    await handleErrorAsync(error, () => {
       showToast('カタログアイテムとカテゴリの取得に失敗しました。')
     })
   }
@@ -249,17 +249,17 @@ const deleteItemAsync = async () => {
     showDeleteNotice.value = true
   } catch (error) {
     if (error instanceof NotFoundError) {
-      customErrorHandler.handle(error, () => {
+      await handleErrorAsync(error, () => {
         showToast('削除対象のカタログアイテムが見つかりませんでした。')
         router.push({ name: '/catalog/items' })
       })
     } else if (error instanceof ConflictError) {
-      customErrorHandler.handle(error, () => {
+      await handleErrorAsync(error, () => {
         showToast('カタログアイテムの更新と削除が競合しました。もう一度削除してください。')
       })
       await reFetchItemAndInitRowVersionAsync(id)
     } else {
-      customErrorHandler.handle(error, () => {
+      await handleErrorAsync(error, () => {
         showToast('カタログアイテムの削除に失敗しました。')
       })
     }
@@ -291,12 +291,12 @@ const updateItemAsync = async () => {
       showToast('更新対象のカタログアイテムが見つかりませんでした。')
       router.push({ name: 'catalog/items' })
     } else if (error instanceof ConflictError) {
-      customErrorHandler.handle(error, () => {
+      await handleErrorAsync(error, () => {
         showToast('カタログアイテムの更新が競合しました。もう一度更新してください。')
       })
       await reFetchItemAndInitRowVersionAsync(id)
     } else {
-      customErrorHandler.handle(error, () => {
+      await handleErrorAsync(error, () => {
         showToast('カタログアイテムの更新に失敗しました。')
       })
     }

--- a/samples/web-csr/dressca-frontend/admin/src/views/catalog/ItemsView.vue
+++ b/samples/web-csr/dressca-frontend/admin/src/views/catalog/ItemsView.vue
@@ -14,7 +14,7 @@ import type {
 import { useCustomErrorHandler } from '@/shared/error-handler/custom-error-handler'
 
 const router = useRouter()
-const customErrorHandler = useCustomErrorHandler()
+const handleErrorAsync = useCustomErrorHandler()
 
 const { toCurrencyJPY } = currencyHelper()
 const { getFirstAssetUrl } = assetHelper()
@@ -87,7 +87,7 @@ onMounted(async () => {
     pagedListOfCatalogItem.value = await fetchItems(0, 0)
     ;[catalogCategories.value, catalogBrands.value] = await fetchCategoriesAndBrands()
   } catch (error) {
-    customErrorHandler.handle(error, () => {
+    await handleErrorAsync(error, () => {
       showToast('カタログアイテムの取得に失敗しました。')
     })
   } finally {

--- a/samples/web-csr/dressca-frontend/consumer/src/shared/error-handler/custom-error-handler.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/shared/error-handler/custom-error-handler.ts
@@ -34,6 +34,8 @@ export function useCustomErrorHandler(): handleErrorAsyncFunction {
     const unauthorizedErrorEventBus = useEventBus(unauthorizedErrorEventKey)
     // ハンドリングできるエラーの場合はコールバックを実行します。
     if (error instanceof CustomErrorBase) {
+      // eslint-disable-next-line no-console
+      console.error(JSON.stringify(error.toJSON()))
       await callback()
       if (error instanceof HttpError) {
         // 業務処理で発生した HttpError を処理します。

--- a/samples/web-csr/dressca-frontend/consumer/src/shared/error-handler/custom-error-handler.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/shared/error-handler/custom-error-handler.ts
@@ -9,85 +9,50 @@ import {
   ServerError,
 } from './custom-error'
 import { unauthorizedErrorEventKey, unhandledErrorEventKey } from '../events'
+import type { MaybeAsyncFunction, MaybePromise, MaybeAsyncUnaryFunction } from '@/types'
 
-export interface CustomErrorHandler {
-  handle(
-    error: unknown,
-    callback: () => void,
-    handlingHttpError?: ((httpError: HttpError) => void) | null,
-    handlingUnauthorizedError?: (() => void) | null,
-    handlingNetworkError?: (() => void) | null,
-    handlingServerError?: (() => void) | null,
-  ): void
-}
+export type handleErrorAsyncFunction = (
+  error: unknown,
+  callback: MaybeAsyncFunction<void>,
+  handlingHttpError?: MaybeAsyncUnaryFunction<HttpError, void> | null,
+  handlingUnauthorizedError?: MaybeAsyncFunction<void> | null,
+  handlingNetworkError?: MaybeAsyncFunction<void> | null,
+  handlingServerError?: MaybeAsyncFunction<void> | null,
+) => MaybePromise<void>
 
-export function useCustomErrorHandler(): CustomErrorHandler {
+export function useCustomErrorHandler(): handleErrorAsyncFunction {
   const { t } = i18n.global
-  const customErrorHandler: CustomErrorHandler = {
-    handle: (
-      error: unknown,
-      callback: () => void,
-      handlingHttpError: ((httpError: HttpError) => void) | null = null,
-      handlingUnauthorizedError: (() => void) | null = null,
-      handlingNetworkError: (() => void) | null = null,
-      handlingServerError: (() => void) | null = null,
-    ) => {
-      const unhandledErrorEventBus = useEventBus(unhandledErrorEventKey)
-      const unauthorizedErrorEventBus = useEventBus(unauthorizedErrorEventKey)
-      // ハンドリングできるエラーの場合はコールバックを実行します。
-      if (error instanceof CustomErrorBase) {
-        callback()
-
-        if (error instanceof HttpError) {
-          // 業務処理で発生した HttpError を処理します。
-          if (handlingHttpError) {
-            handlingHttpError(error)
-          }
-          // エラーの種類によって共通処理を行う
-          // switch だと instanceof での判定ができないため if 文で判定します。
-          if (error instanceof UnauthorizedError) {
-            if (handlingUnauthorizedError) {
-              handlingUnauthorizedError()
-            } else {
-              unauthorizedErrorEventBus.emit({
-                details: t('loginRequiredError'),
-              })
-              // ProblemDetail の構造に依存します。
-              if (!error.response?.exceptionId) {
-                unhandledErrorEventBus.emit({
-                  message: t('loginRequiredError'),
-                })
-              } else {
-                const message = errorMessageFormat(
-                  error.response.exceptionId,
-                  error.response.exceptionValues,
-                )
-                unhandledErrorEventBus.emit({
-                  message,
-                  id: error.response.exceptionId,
-                  title: error.response.title,
-                  detail: error.response.detail,
-                  status: error.response.status,
-                  timeout: 100000,
-                })
-              }
-            }
-          } else if (error instanceof NetworkError) {
-            if (handlingNetworkError) {
-              handlingNetworkError()
-            } else {
-              // NetworkError ではエラーレスポンスが存在しないため ProblemDetails の処理は実施しません。
+  const handleErrorAsync = async (
+    error: unknown,
+    callback: MaybeAsyncFunction<void>,
+    handlingHttpError: MaybeAsyncUnaryFunction<HttpError, void> | null = null,
+    handlingUnauthorizedError: MaybeAsyncFunction<void> | null = null,
+    handlingNetworkError: MaybeAsyncFunction<void> | null = null,
+    handlingServerError: MaybeAsyncFunction<void> | null = null,
+  ) => {
+    const unhandledErrorEventBus = useEventBus(unhandledErrorEventKey)
+    const unauthorizedErrorEventBus = useEventBus(unauthorizedErrorEventKey)
+    // ハンドリングできるエラーの場合はコールバックを実行します。
+    if (error instanceof CustomErrorBase) {
+      await callback()
+      if (error instanceof HttpError) {
+        // 業務処理で発生した HttpError を処理します。
+        if (handlingHttpError) {
+          await handlingHttpError(error)
+        }
+        // エラーの種類によって共通処理を行う
+        // switch だと instanceof での判定ができないため if 文で判定します。
+        if (error instanceof UnauthorizedError) {
+          if (handlingUnauthorizedError) {
+            await handlingUnauthorizedError()
+          } else {
+            unauthorizedErrorEventBus.emit({
+              details: t('loginRequiredError'),
+            })
+            // ProblemDetail の構造に依存します。
+            if (!error.response?.exceptionId) {
               unhandledErrorEventBus.emit({
-                message: t('networkError'),
-              })
-            }
-          } else if (error instanceof ServerError) {
-            if (handlingServerError) {
-              handlingServerError()
-              // ProblemDetail の構造に依存します。
-            } else if (!error.response?.exceptionId) {
-              unhandledErrorEventBus.emit({
-                message: t('serverError'),
+                message: t('loginRequiredError'),
               })
             } else {
               const message = errorMessageFormat(
@@ -104,12 +69,43 @@ export function useCustomErrorHandler(): CustomErrorHandler {
               })
             }
           }
+        } else if (error instanceof NetworkError) {
+          if (handlingNetworkError) {
+            await handlingNetworkError()
+          } else {
+            // NetworkError ではエラーレスポンスが存在しないため ProblemDetails の処理は実施しません。
+            unhandledErrorEventBus.emit({
+              message: t('networkError'),
+            })
+          }
+        } else if (error instanceof ServerError) {
+          if (handlingServerError) {
+            await handlingServerError()
+            // ProblemDetail の構造に依存します。
+          } else if (!error.response?.exceptionId) {
+            unhandledErrorEventBus.emit({
+              message: t('serverError'),
+            })
+          } else {
+            const message = errorMessageFormat(
+              error.response.exceptionId,
+              error.response.exceptionValues,
+            )
+            unhandledErrorEventBus.emit({
+              message,
+              id: error.response.exceptionId,
+              title: error.response.title,
+              detail: error.response.detail,
+              status: error.response.status,
+              timeout: 100000,
+            })
+          }
         }
-      } else {
-        // ハンドリングできないエラーの場合は上位にエラーを再スローします。
-        throw error
       }
-    },
+    } else {
+      // ハンドリングできないエラーの場合は上位にエラーを再スローします。
+      throw error
+    }
   }
-  return customErrorHandler
+  return handleErrorAsync
 }

--- a/samples/web-csr/dressca-frontend/consumer/src/types/index.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/types/index.ts
@@ -1,0 +1,26 @@
+/**
+ * 同期値または Promise にラップされた非同期値を表すユーティリティ型です。
+ *
+ * @typeParam T - 値の型。
+ *
+ */
+export type MaybePromise<T> = T | Promise<T>
+
+/**
+ * 引数なしの関数で、戻り値が同期/非同期のどちらでもよい関数を表すユーティリティ型です。
+ *
+ * @typeParam R - 解決後の戻り値の型。
+ * @returns 同期値 `R` もしくは `Promise<R>`。
+ * @see MaybePromise
+ */
+export type MaybeAsyncFunction<R> = () => MaybePromise<R>
+
+/**
+ * 引数が 1 つ(unary)で、戻り値が同期/非同期のいずれでもよい関数を表すユーティリティ型です。
+ *
+ * @typeParam T - 引数（`source`）の型。
+ * @typeParam R - 解決後の戻り値の型。
+ * @param source - 関数の引数。
+ * @returns `R` または `Promise<R>`。
+ */
+export type MaybeAsyncUnaryFunction<T, R> = (source: T) => MaybePromise<R>

--- a/samples/web-csr/dressca-frontend/consumer/src/views/basket/BasketView.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/basket/BasketView.vue
@@ -24,7 +24,7 @@ const basketStore = useBasketStore()
 const { getBasket, getAddedItem, getAddedItemId, getDeletedItemIds } = storeToRefs(basketStore)
 
 const router = useRouter()
-const customErrorHandler = useCustomErrorHandler()
+const handleErrorAsync = useCustomErrorHandler()
 const { toCurrencyJPY } = currencyHelper()
 const { getFirstAssetUrl } = assetHelper()
 const { t } = i18n.global
@@ -41,7 +41,7 @@ const update = async (catalogItemId: number, newQuantity: number) => {
   try {
     await updateItemInBasket(catalogItemId, newQuantity)
   } catch (error) {
-    customErrorHandler.handle(
+    await handleErrorAsync(
       error,
       () => {},
       (httpError: HttpError) => {
@@ -71,7 +71,7 @@ const remove = async (catalogItemId: number) => {
   try {
     await removeItemFromBasket(catalogItemId)
   } catch (error) {
-    customErrorHandler.handle(
+    await handleErrorAsync(
       error,
       () => {},
       (httpError: HttpError) => {
@@ -113,7 +113,7 @@ onMounted(async () => {
       showToast(t('basketContainsUnavailableItem'))
     }
   } catch (error) {
-    customErrorHandler.handle(
+    await handleErrorAsync(
       error,
       () => {},
       (httpError: HttpError) => {

--- a/samples/web-csr/dressca-frontend/consumer/src/views/catalog/CatalogView.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/catalog/CatalogView.vue
@@ -22,7 +22,7 @@ const catalogStore = useCatalogStore()
 const { getSpecialContents } = storeToRefs(specialContentStore)
 const { getCategories, getBrands, getItems, getBrandName } = storeToRefs(catalogStore)
 const router = useRouter()
-const customErrorHandler = useCustomErrorHandler()
+const handleErrorAsync = useCustomErrorHandler()
 const { t } = i18n.global
 
 const selectedCategory = ref(0)
@@ -37,7 +37,7 @@ const addBasket = async (catalogItemId: number) => {
     await addItemToBasket(catalogItemId)
     router.push({ name: 'basket' })
   } catch (error) {
-    customErrorHandler.handle(
+    await handleErrorAsync(
       error,
       () => {},
       (httpError: HttpError) => {
@@ -68,7 +68,7 @@ onMounted(async () => {
   try {
     await fetchItems(selectedCategory.value, selectedBrand.value)
   } catch (error) {
-    customErrorHandler.handle(
+    await handleErrorAsync(
       error,
       () => {},
       (httpError: HttpError) => {

--- a/samples/web-csr/dressca-frontend/consumer/src/views/ordering/CheckoutView.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/ordering/CheckoutView.vue
@@ -20,7 +20,7 @@ const basketStore = useBasketStore()
 const { getBasket } = storeToRefs(basketStore)
 const { getAddress } = storeToRefs(userStore)
 const router = useRouter()
-const customErrorHandler = useCustomErrorHandler()
+const handleErrorAsync = useCustomErrorHandler()
 const { toCurrencyJPY } = currencyHelper()
 const { getFirstAssetUrl } = assetHelper()
 const { t } = i18n.global
@@ -36,7 +36,7 @@ const checkout = async () => {
     )
     router.push({ name: 'ordering/done', params: { orderId } })
   } catch (error) {
-    customErrorHandler.handle(
+    await handleErrorAsync(
       error,
       () => {
         router.push({ name: 'error' })

--- a/samples/web-csr/dressca-frontend/consumer/src/views/ordering/DoneView.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/ordering/DoneView.vue
@@ -13,7 +13,7 @@ import { LoadingSpinnerOverlay } from '@/components/common/LoadingSpinnerOverlay
 import { useCustomErrorHandler } from '@/shared/error-handler/custom-error-handler'
 
 const router = useRouter()
-const customErrorHandler = useCustomErrorHandler()
+const handleErrorAsync = useCustomErrorHandler()
 const props = defineProps<{
   orderId: number
 }>()
@@ -35,7 +35,7 @@ onMounted(async () => {
   try {
     lastOrdered.value = await getOrder(props.orderId)
   } catch (error) {
-    customErrorHandler.handle(
+    await handleErrorAsync(
       error,
       () => {
         router.push('/')


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

### コード修正

カスタムエラーハンドラーのコールバック関数で非同期処理を受け入れ可能にしました。
- 戻り値が`Promise`になる可能性がある非同期関数を表す型を定義しました。
- これらの型をカスタムエラーハンドラーの型に割り当てました。
- 呼び出し元を修正しました。

### 確認ポイント
- mock モードでカスタムエラーを発生させ、正常に引き渡したメソッドが実行されることと、画面の見え方が変わっていないことを確認しました。
- 特に `UnauthorizedError` の共通処理（router.push() によるログイン画面へのリダイレクト）について確認しました。

### 本質的でない修正
- 呼び出し元で handler.handle という冗長な名称の呼び出しをしなくて済むようにリファクタリングしました。
- このことによってエラーをハンドリングするという意図がわかりにくくなることを防ぐために、 handleErrorAsync にメソッド名を修正しました。

### ついでに実施した細かい修正
- consumer のカスタムエラーハンドラーで、JSON形式のログを出力するよう修正しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->