### PR TITLE
External IDサンプルの実装に合わせて Dressca アプリを修正する

### DIFF
--- a/samples/web-csr/dressca-frontend/admin/src/api-client/index.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/api-client/index.ts
@@ -54,20 +54,33 @@ axiosInstance.interceptors.response.use(
 /**
  * カタログブランド API のクライアントです。
  */
-const catalogBrandsApi = new apiClient.CatalogBrandsApi(createConfig(), '', axiosInstance)
+function catalogBrandsApi() {
+  const catalogBrandsApi = new apiClient.CatalogBrandsApi(createConfig(), '', axiosInstance)
+  return catalogBrandsApi
+}
 
 /**
  * カタログカテゴリ API のクライアントです。
  */
-const catalogCategoriesApi = new apiClient.CatalogCategoriesApi(createConfig(), '', axiosInstance)
+function catalogCategoriesApi() {
+  const catalogCategoriesApi = new apiClient.CatalogCategoriesApi(createConfig(), '', axiosInstance)
+  return catalogCategoriesApi
+}
 
 /**
  * カタログアイテム API のクライアントです。
  */
-const catalogItemsApi = new apiClient.CatalogItemsApi(createConfig(), '', axiosInstance)
+function catalogItemsApi() {
+  const catalogItemsApi = new apiClient.CatalogItemsApi(createConfig(), '', axiosInstance)
+  return catalogItemsApi
+}
 
 /**
  * ユーザー API のクライアントです。
  */
-const UsersApi = new apiClient.UsersApi(createConfig(), '', axiosInstance)
-export { catalogBrandsApi, catalogCategoriesApi, catalogItemsApi, UsersApi }
+function usersApi() {
+  const usersApi = new apiClient.UsersApi(createConfig(), '', axiosInstance)
+  return usersApi
+}
+
+export { catalogBrandsApi, catalogCategoriesApi, catalogItemsApi, usersApi }

--- a/samples/web-csr/dressca-frontend/admin/src/services/catalog/catalog-service.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/services/catalog/catalog-service.ts
@@ -13,7 +13,7 @@ import type {
  * @returns カタログカテゴリの配列。
  */
 export async function fetchCategories(): Promise<GetCatalogCategoriesResponse[]> {
-  const response = await catalogCategoriesApi.getCatalogCategories()
+  const response = await catalogCategoriesApi().getCatalogCategories()
   return response.data
 }
 
@@ -22,7 +22,7 @@ export async function fetchCategories(): Promise<GetCatalogCategoriesResponse[]>
  * @returns カテゴリブランドの配列。
  */
 export async function fetchBrands(): Promise<GetCatalogBrandsResponse[]> {
-  const response = await catalogBrandsApi.getCatalogBrands()
+  const response = await catalogBrandsApi().getCatalogBrands()
   return response.data
 }
 
@@ -50,7 +50,7 @@ export async function fetchItems(
   brandId: number,
   page?: number,
 ): Promise<PagedListOfGetCatalogItemResponse> {
-  const response = await catalogItemsApi.getByQuery(
+  const response = await catalogItemsApi().getByQuery(
     brandId === 0 ? undefined : brandId,
     categoryId === 0 ? undefined : categoryId,
     page,
@@ -65,7 +65,7 @@ export async function fetchItems(
  * @returns カタログアイテムの情報。
  */
 export async function fetchItem(itemId: number): Promise<GetCatalogItemResponse> {
-  const itemResponse = await catalogItemsApi.getCatalogItem(itemId)
+  const itemResponse = await catalogItemsApi().getCatalogItem(itemId)
   return itemResponse.data
 }
 
@@ -94,7 +94,7 @@ export async function postCatalogItem(
     catalogCategoryId,
     catalogBrandId,
   }
-  await catalogItemsApi.postCatalogItem(postCatalogItemInput)
+  await catalogItemsApi().postCatalogItem(postCatalogItemInput)
 }
 
 /**
@@ -129,7 +129,7 @@ export async function updateCatalogItem(
     rowVersion,
     isDeleted,
   }
-  await catalogItemsApi.putCatalogItem(id, putCatalogItemRequest)
+  await catalogItemsApi().putCatalogItem(id, putCatalogItemRequest)
 }
 
 /**
@@ -138,5 +138,5 @@ export async function updateCatalogItem(
  * @param rowVersion 排他制御のための行バージョン。
  */
 export async function deleteCatalogItem(id: number, rowVersion: string) {
-  await catalogItemsApi.deleteCatalogItem(id, rowVersion)
+  await catalogItemsApi().deleteCatalogItem(id, rowVersion)
 }

--- a/samples/web-csr/dressca-frontend/admin/src/stores/authentication/authentication.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/stores/authentication/authentication.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { UsersApi } from '@/api-client'
+import { usersApi } from '@/api-client'
 
 /**
  * 認証状態のストアです。
@@ -18,7 +18,7 @@ export const useAuthenticationStore = defineStore('authentication', {
      * セッションストレージに認証状態を保存します。
      */
     async signInAsync() {
-      const response = await UsersApi.getLoginUser()
+      const response = await usersApi().getLoginUser()
       const { userName, roles } = response.data
       this.userName = userName
       this.userRoles = roles

--- a/samples/web-csr/dressca-frontend/consumer/src/App.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/App.vue
@@ -1,14 +1,12 @@
 <script setup lang="ts">
 import { ShoppingCartIcon } from '@heroicons/vue/24/solid'
-import { storeToRefs } from 'pinia'
-import { useAuthenticationStore } from '@/stores/authentication/authentication'
 import { router } from '@/router'
 import { useEventBus } from '@vueuse/core'
 import NotificationToast from './components/common/NotificationToast.vue'
 import { unauthorizedErrorEventKey } from './shared/events'
+import { authenticationService } from './services/authentication/authentication-service'
 
-const authenticationStore = useAuthenticationStore()
-const { isAuthenticated } = storeToRefs(authenticationStore)
+const { isAuthenticated } = authenticationService()
 
 const unauthorizedErrorEventBus = useEventBus(unauthorizedErrorEventKey)
 
@@ -44,7 +42,9 @@ unauthorizedErrorEventBus.on(() => {
             <router-link to="/basket">
               <ShoppingCartIcon class="h-8 w-8 text-amber-600" />
             </router-link>
-            <router-link v-if="!isAuthenticated" to="/authentication/login"> ログイン </router-link>
+            <router-link v-if="!isAuthenticated()" to="/authentication/login">
+              ログイン
+            </router-link>
           </div>
         </div>
       </nav>

--- a/samples/web-csr/dressca-frontend/consumer/src/api-client/index.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/api-client/index.ts
@@ -41,12 +41,35 @@ axiosInstance.interceptors.response.use(
   },
 )
 
-const assetsApi = new apiClient.AssetsApi(createConfig(), '', axiosInstance)
-const basketItemsApi = new apiClient.BasketItemsApi(createConfig(), '', axiosInstance)
-const catalogBrandsApi = new apiClient.CatalogBrandsApi(createConfig(), '', axiosInstance)
-const catalogCategoriesApi = new apiClient.CatalogCategoriesApi(createConfig(), '', axiosInstance)
-const catalogItemsApi = new apiClient.CatalogItemsApi(createConfig(), '', axiosInstance)
-const ordersApi = new apiClient.OrdersApi(createConfig(), '', axiosInstance)
+function assetsApi() {
+  const assetsApi = new apiClient.AssetsApi(createConfig(), '', axiosInstance)
+  return assetsApi
+}
+
+function basketItemsApi() {
+  const basketItemsApi = new apiClient.BasketItemsApi(createConfig(), '', axiosInstance)
+  return basketItemsApi
+}
+
+function catalogBrandsApi() {
+  const catalogBrandsApi = new apiClient.CatalogBrandsApi(createConfig(), '', axiosInstance)
+  return catalogBrandsApi
+}
+
+function catalogCategoriesApi() {
+  const catalogCategoriesApi = new apiClient.CatalogCategoriesApi(createConfig(), '', axiosInstance)
+  return catalogCategoriesApi
+}
+
+function catalogItemsApi() {
+  const catalogItemsApi = new apiClient.CatalogItemsApi(createConfig(), '', axiosInstance)
+  return catalogItemsApi
+}
+
+function ordersApi() {
+  const ordersApi = new apiClient.OrdersApi(createConfig(), '', axiosInstance)
+  return ordersApi
+}
 
 export {
   assetsApi,
@@ -55,5 +78,4 @@ export {
   catalogCategoriesApi,
   catalogItemsApi,
   ordersApi,
-  axiosInstance,
 }

--- a/samples/web-csr/dressca-frontend/consumer/src/api-client/index.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/api-client/index.ts
@@ -72,6 +72,7 @@ function ordersApi() {
 }
 
 export {
+  axiosInstance,
   assetsApi,
   basketItemsApi,
   catalogBrandsApi,

--- a/samples/web-csr/dressca-frontend/consumer/src/services/authentication/authentication-service.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/services/authentication/authentication-service.ts
@@ -1,6 +1,19 @@
 import { useAuthenticationStore } from '@/stores/authentication/authentication'
 
-export function signIn() {
-  const authenticationStore = useAuthenticationStore()
-  authenticationStore.signIn()
+export function authenticationService() {
+  const signIn = () => {
+    const authenticationStore = useAuthenticationStore()
+    authenticationStore.signIn()
+  }
+
+  const isAuthenticated = (): boolean => {
+    const authenticationStore = useAuthenticationStore()
+    const result = authenticationStore.isAuthenticated
+    return result
+  }
+
+  return {
+    signIn,
+    isAuthenticated,
+  }
 }

--- a/samples/web-csr/dressca-frontend/consumer/src/services/ordering/ordering-service.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/services/ordering/ordering-service.ts
@@ -18,13 +18,13 @@ export async function postOrder(
     shikuchoson,
     azanaAndOthers,
   }
-  const orderResponse = await ordersApi.postOrder(postOrderInput)
+  const orderResponse = await ordersApi().postOrder(postOrderInput)
   const url = new URL(orderResponse.headers.location)
   return Number(url.pathname.split('/').pop())
 }
 
 // ordering/done/:orderId の onMounted() から呼び出されて注文情報を取得
 export async function getOrder(orderId: number): Promise<OrderResponse> {
-  const orderResultResponse = await ordersApi.getById(orderId)
+  const orderResultResponse = await ordersApi().getById(orderId)
   return orderResultResponse.data
 }

--- a/samples/web-csr/dressca-frontend/consumer/src/stores/basket/basket.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/stores/basket/basket.ts
@@ -19,7 +19,7 @@ export const useBasketStore = defineStore('basket', {
         catalogItemId,
         addedQuantity: 1,
       }
-      await basketItemsApi.postBasketItem(params)
+      await basketItemsApi().postBasketItem(params)
       this.addedItemId = catalogItemId
     },
     async update(catalogItemId: number, newQuantity: number) {
@@ -29,13 +29,13 @@ export const useBasketStore = defineStore('basket', {
           quantity: newQuantity,
         },
       ]
-      await basketItemsApi.putBasketItems(params)
+      await basketItemsApi().putBasketItems(params)
     },
     async remove(catalogItemId: number) {
-      await basketItemsApi.deleteBasketItem(catalogItemId)
+      await basketItemsApi().deleteBasketItem(catalogItemId)
     },
     async fetch() {
-      const response = await basketItemsApi.getBasketItems()
+      const response = await basketItemsApi().getBasketItems()
       this.basket = response.data
       this.deletedItemIds = response.data.deletedItemIds ?? []
     },

--- a/samples/web-csr/dressca-frontend/consumer/src/stores/catalog/catalog.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/stores/catalog/catalog.ts
@@ -14,17 +14,17 @@ export const useCatalogStore = defineStore('catalog', {
   }),
   actions: {
     async fetchCategories() {
-      const response = await catalogCategoriesApi.getCatalogCategories()
+      const response = await catalogCategoriesApi().getCatalogCategories()
       this.categories = response.data
       this.categories.unshift({ id: 0, name: 'すべて' })
     },
     async fetchBrands() {
-      const response = await catalogBrandsApi.getCatalogBrands()
+      const response = await catalogBrandsApi().getCatalogBrands()
       this.brands = response.data
       this.brands.unshift({ id: 0, name: 'すべて' })
     },
     async fetchItems(categoryId: number, brandId: number, page?: number) {
-      const response = await catalogItemsApi.getByQuery(
+      const response = await catalogItemsApi().getByQuery(
         brandId === 0 ? undefined : brandId,
         categoryId === 0 ? undefined : categoryId,
         page,

--- a/samples/web-csr/dressca-frontend/consumer/src/views/__tests__/basket/BasketView.spec.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/__tests__/basket/BasketView.spec.ts
@@ -76,9 +76,10 @@ const { getBasketItemsMock } = vi.hoisted(() => {
 })
 
 vi.mock('@/api-client', () => ({
-  basketItemsApi: {
+  // basketItemsApi() を呼ぶと { getBasketItems: getBasketItemsMock } が返る
+  basketItemsApi: () => ({
     getBasketItems: getBasketItemsMock,
-  },
+  }),
 }))
 
 function getWrapper() {

--- a/samples/web-csr/dressca-frontend/consumer/src/views/authentication/LoginView.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/authentication/LoginView.vue
@@ -2,7 +2,7 @@
 import { useRoute, useRouter } from 'vue-router'
 import { useField, useForm } from 'vee-validate'
 import * as yup from 'yup'
-import { signIn as signInByService } from '@/services/authentication/authentication-service'
+import { authenticationService } from '@/services/authentication/authentication-service'
 import { EnvelopeIcon, KeyIcon } from '@heroicons/vue/24/solid'
 import { configureYup } from '@/config/yup.config'
 import { ValidationItems } from '@/validation/validation-items'
@@ -27,8 +27,10 @@ const isInvalid = () => {
   return !meta.value.valid
 }
 
-const signIn = () => {
-  signInByService()
+const { signIn } = authenticationService()
+
+const signInOnClick = () => {
+  signIn()
   // 別の画面からリダイレクトしていない場合は、トップページに遷移します。
   if (!route.query.redirectName) {
     router.push({ name: 'catalog' })
@@ -78,7 +80,7 @@ const signIn = () => {
           type="button"
           class="w-full rounded-sm bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700 disabled:bg-blue-500/50"
           :disabled="isInvalid()"
-          @click="signIn"
+          @click="signInOnClick"
         >
           ログイン
         </button>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

External ID サンプルの実装に合わせて Dressca アプリを以下のように修正しました。

- LoginView では SignIn 用のサービスを import して各変数を呼び出す
- api-client の各 API 呼び出しで動的に Token 取得できるようメソッド呼び出しに変更する
- unitTest をメソッド呼び出しに合わせて修正する

Token 取得する場合には以下のように Token 呼び出し用のメソッドが追加されるイメージです。

```ts
export async function ordersApi(): Promise<apiClient.OrdersApi> {
  const config = createConfig()
  await addTokenAsync(config)
  const orderApi = new apiClient.OrdersApi(config, '', axiosInstance)
  return orderApi
}
```

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #3094

<!-- I want to review in Japanese. -->