### PR TITLE
不要になった postcss に関する記述を削除する 

### DIFF
--- a/documents/contents/guidebooks/how-to-develop/vue-js/project-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/project-settings.md
@@ -61,9 +61,8 @@ Project Reference 機能については [Project References :material-open-in-ne
     `include` キーにパターンを追加しています。この段階では実際にこれらのファイルを追加で作成する必要はありません。
     mock フォルダーと配下のファイルは、[モックモードの設定 - Mock Service Worker の設定](./mock-mode-settings.md#msw-settings) で作成します。
     vitest.setup.ts は、 Vitest での自動テスト実行前後の共通処理を定義するファイルです。
-    postcss.config.ts は [CSS の設定 - PostCSS の設定](./css.md#settings-postcss) で作成します。
 
-    ```json title="サンプルアプリケーション の tsconfig.app.json" hl_lines="7-9"
+    ```json title="サンプルアプリケーション の tsconfig.app.json" hl_lines="3"
     https://github.com/AlesInfiny/maia/blob/main/samples/web-csr/dressca-frontend/consumer/tsconfig.app.json
     ```
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと
[tscofig.app.json の設定例](http://127.0.0.1:8000/guidebooks/how-to-develop/vue-js/project-settings/#tsconfig)
について、 Tailwind CSS v4 への移行により postcss.config.ts を削除したので、
ドキュメントからも postcss に関する記述を削除し、リンク切れを解消しました。
あわせて、ハイライト行も incluede キーの行を示すように修正しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク
下記にて検出

- https://github.com/AlesInfiny/maia/pull/3137#discussion_r2400477073

<!-- I want to review in Japanese. -->