### PR TITLE
複合アクションファイルがチェック対象になるように dependabot の設定を修正する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/.github/workflows"
-      - "/.github/workflows/*/action.yml"
+      - "/.github/workflows/**/action.yml"
     schedule:
       interval: "daily"
     cooldown:


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

複合アクションファイルがチェック対象になるように dependabot の設定を修正しました。
`directories` オプションと glob パターンを用いて ./github/workflows ファイルを再帰的に検索するようにしました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

[リファレンス
](https://docs.github.com/ja/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-%E3%81%BE%E3%81%9F%E3%81%AF-directory--)
[設定例
](https://docs.github.com/ja/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#defining-multiple-locations-for-manifest-files)
<!-- I want to review in Japanese. -->