### PR TITLE
Dressca と AzureADB2CAuth について Spring Boot 3.5.5 SpotBugsTool 4.8.6 にバージョンを同期

### DIFF
--- a/samples/azure-ad-b2c-sample/auth-backend/dependencies.gradle
+++ b/samples/azure-ad-b2c-sample/auth-backend/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
     // -- TOOLS
     jacocoToolVersion = "0.8.14"
     checkstyleToolVersion = "12.0.1"
-    spotbugsToolVersion = "4.9.6"
+    spotbugsToolVersion = "4.8.6"
 
     // -- DEPENDENCIES
     springdocOpenapiVersion = "2.8.13"

--- a/samples/web-csr/dressca-backend/dependencies.gradle
+++ b/samples/web-csr/dressca-backend/dependencies.gradle
@@ -1,6 +1,6 @@
 ext {
     // -- PLUGINS
-    springBootVersion = "3.5.6"
+    springBootVersion = "3.5.5"
     springDependencyManagementVersion = "1.1.7"
     springdocOpenapiGradlePluginVersion = "1.9.0"
     spotbugsVersion = "6.4.2"


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと
- Dressca と AzureADB2CAuth のバックエンドで使用するライブラリバージョンについて Spring Boot 3.5.5 SpotBugsTool 4.8.6 にバージョンを同期しました。

### Spring Boot
spring-cloud-azure のリリースノートに、 Spring Bott 3.5.5 までしかテストされていない旨の記述があるため。

- https://github.com/Azure/azure-sdk-for-java/releases/tag/spring-cloud-azure_6.0.0
>This release is compatible with Spring Boot 3.5.0-3.5.5. (Note: 3.5.x (x>5) should be supported, but they aren't tested with this release.)
- https://github.com/AlesInfiny/maia/issues/3180#issuecomment-3404174527

### SpotBugsTool
4.9.6 にアップデートすると、SpotBugsがエラーで落ちるため、現行バージョンに留めておく。詳細は下記。
- https://github.com/AlesInfiny/maia/issues/3180#issuecomment-3408791323

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

上述の通り。

<!-- I want to review in Japanese. -->