### PR TITLE
packageManagerフィールドにハッシュ値のメタデータの付与をやめる

### DIFF
--- a/samples/azure-ad-b2c-sample/auth-frontend/package.json
+++ b/samples/azure-ad-b2c-sample/auth-frontend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "private": "true",
-  "packageManager": "npm@10.9.3+sha512-6Eh1u5Q+kIVXeA8e7l2c/HpnFFcwrkt37xDMujD5be1gloWa9p6j3Fsv3mByXXmqJHy+2cElRMML8opNT7xIJQ==",
+  "packageManager": "npm@10.9.3",
   "scripts": {
     "format:root": "prettier --write ./*.{js,ts,json,yaml}",
     "format:ci:root": "prettier --check ./*.{js,ts,json,yaml}",

--- a/samples/web-csr/dressca-frontend/package.json
+++ b/samples/web-csr/dressca-frontend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "private": "true",
-  "packageManager": "npm@10.9.3+sha512-6Eh1u5Q+kIVXeA8e7l2c/HpnFFcwrkt37xDMujD5be1gloWa9p6j3Fsv3mByXXmqJHy+2cElRMML8opNT7xIJQ==",
+  "packageManager": "npm@10.9.3",
   "scripts": {
     "format:root": "prettier --write ./*.{js,ts,json,yaml}",
     "format:ci:root": "prettier --check ./*.{js,ts,json,yaml}",


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと
#3215 の対応の結果、setup-node は ハッシュ値のメタデータ付きの `packageManager` フィールドを解釈できるが、 dependabot は解釈できないため dependabot の実行に失敗している。
そのため、ハッシュ値を削除し、セマンティックバージョン表記のみに修正する。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク
- dependabot のドキュメントで明確にフォーマットを指定している記述はないが、
下記のようにセマンティックバージョン表記でなければならないというエラーメッセージが出力され実行に失敗する。

https://github.com/AlesInfiny/maia/network/updates/1126533793

```text
Invalid package manager specification in package.json. The packageManager field must specify a valid semver version
```

<!-- I want to review in Japanese. -->