### PR TITLE
setup-node 6.0.0 にバージョンアップする

### DIFF
--- a/.github/workflows/samples-azure-ad-b2c-ci.yml
+++ b/.github/workflows/samples-azure-ad-b2c-ci.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 1
 
       - name: Use Node.js LTS
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v6.0.0
         with:
           node-version: lts/*
           # See supported Node.js release schedule at https://nodejs.org/en/about/releases/

--- a/.github/workflows/samples-dressca-admin-frontend.ci.yml
+++ b/.github/workflows/samples-dressca-admin-frontend.ci.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Use Node.js LTS
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v6.0.0
         with:
           node-version: lts/*
           # See supported Node.js release schedule at https://nodejs.org/en/about/releases/

--- a/.github/workflows/samples-dressca-consumer-frontend.ci.yml
+++ b/.github/workflows/samples-dressca-consumer-frontend.ci.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Use Node.js LTS
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v6.0.0
         with:
           node-version: lts/*
           # See supported Node.js release schedule at https://nodejs.org/en/about/releases/

--- a/.github/workflows/samples-dressca-root-frontend-ci.yml
+++ b/.github/workflows/samples-dressca-root-frontend-ci.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Use Node.js LTS
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v6.0.0
         with:
           node-version: lts/*
           # See supported Node.js release schedule at https://nodejs.org/en/about/releases/


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

- setup-node 6.0.0 に更新しました。
    - ハッシュ値とバージョン表記を更新しました。

## この Pull request では実施していないこと

- package.json の `packageManager` に npm が指定されていれば自動キャッシュが効くようになったとありますが、動作を確認したところ効いていないように見えるため、`cache : npm` の設定は残したままにしました。
- `cache : npm` の設定があれば v6 でもキャッシュ/キャッシュ復元されることを確認しました。

## Issues や Discussions 、関連する Web サイトなどへのリンク

https://github.com/actions/setup-node/releases/tag/v6.0.0

<!-- I want to review in Japanese. -->