### PR TITLE
Spring 関連のドキュメントへのリンクを最新化する

### DIFF
--- a/documents/contents/app-architecture/batch-application/batch-application-test-policy/integration-test.md
+++ b/documents/contents/app-architecture/batch-application/batch-application-test-policy/integration-test.md
@@ -20,7 +20,7 @@ description: バッチアプリケーションのテスト方針における 結
 
 - [JUnit :material-open-in-new:](https://junit.org/){ target=_blank }
     - Java のテストフレームワークです。
-- [Spring Test :material-open-in-new:](https://spring.pleiades.io/spring-framework/docs/current/reference/html/testing.html){ target=_blank }
+- [Spring Test :material-open-in-new:](https://spring.pleiades.io/spring-framework/reference/testing.html){ target=_blank }
     - Spring で構築したアプリケーションのテストを実行するためのツールセットです。
     - 主に Spring Boot アプリケーションのランタイムを結合テスト用に初期化するため使用します。
 - [Spring Batch Test :material-open-in-new:](https://spring.pleiades.io/spring-batch/reference/testing.html){ target=_blank }

--- a/documents/contents/app-architecture/client-side-rendering/csr-architecture-overview.md
+++ b/documents/contents/app-architecture/client-side-rendering/csr-architecture-overview.md
@@ -78,7 +78,7 @@ AlesInfiny Maia OSS Edition （以降、 AlesInfiny Maia）において、クラ
 
 ??? note "利用ライブラリ（バックエンド）"
 
-    - [Spring Core :material-open-in-new:](https://spring.pleiades.io/spring-framework/docs/current/reference/html/core.html#spring-core){ target=_blank }
+    - [Spring Core :material-open-in-new:](https://spring.pleiades.io/spring-framework/reference/core.html){ target=_blank }
     
         DI コンテナや AOP の機能を提供する Spring Framework のコアライブラリです。
         ベースとなる Spring Framework のコアライブラリや、 Spring Framework の自動設定サポートを含む Spring Boot の機能を提供します。
@@ -88,7 +88,7 @@ AlesInfiny Maia OSS Edition （以降、 AlesInfiny Maia）において、クラ
         Spring Framework をベースとするアプリケーション開発を効率的に行うためのフレームワークです。
         Spring Framework の課題である煩雑な Bean 定義や設定ファイルを可能な限り自動設定したり、実装するコード量を軽減するアノテーションを提供します。
 
-    - [Spring MVC :material-open-in-new:](https://spring.pleiades.io/spring-framework/docs/current/reference/html/web.html#mvc){ target=_blank }
+    - [Spring MVC :material-open-in-new:](https://spring.pleiades.io/spring-framework/reference/web/webmvc.html){ target=_blank }
 
         Spring MVC は Spring Framework をベースとする Front Controller パターンの Web MVC フレームワークです。
 
@@ -97,7 +97,7 @@ AlesInfiny Maia OSS Edition （以降、 AlesInfiny Maia）において、クラ
         Bean に対するデータの値チェック機能を提供するライブラリです。
         アノテーションベースで汎用的に利用できる値チェックが提供され、入力値チェック等が簡潔に実現できます。
 
-    - [Spring Test :material-open-in-new:](https://spring.pleiades.io/spring-framework/docs/current/reference/html/testing.html){ target=_blank }
+    - [Spring Test :material-open-in-new:](https://spring.pleiades.io/spring-framework/reference/testing.html){ target=_blank }
 
         Spring Framework をベースとするアプリケーション実装をテストするためのライブラリです。
         Unit Jupiter 、 Hamcrest 、 Mockito などのライブラリと連携して、テスト実装をサポートする機能を提供します。

--- a/documents/contents/app-architecture/client-side-rendering/global-function/health-check-implementation.md
+++ b/documents/contents/app-architecture/client-side-rendering/global-function/health-check-implementation.md
@@ -28,7 +28,7 @@ AlesInfiny Maia において定義しているヘルスチェックの実装例�
 
 <!-- textlint-disable ja-technical-writing/sentence-length -->
 
-Spring Boot を用いた Web アプリケーションでは、 [Spring Boot Actuator :material-open-in-new:](https://spring.pleiades.io/spring-boot/docs/current/reference/html/actuator.html){ target=_blank } を利用することで比較適容易にヘルスチェック機能を実装可能です。
+Spring Boot を用いた Web アプリケーションでは、 [Spring Boot Actuator :material-open-in-new:](https://spring.pleiades.io/spring-boot/reference/actuator/){ target=_blank } を利用することで比較適容易にヘルスチェック機能を実装可能です。
 Spring Boot Actuator はアプリケーションレベルでサーバーを監視、管理する追加機能を提供するモジュールです。
 
 <!-- textlint-enable ja-technical-writing/sentence-length -->

--- a/documents/contents/app-architecture/client-side-rendering/test/backend-application/integration-test.md
+++ b/documents/contents/app-architecture/client-side-rendering/test/backend-application/integration-test.md
@@ -18,7 +18,7 @@ description: バックエンドアプリケーションのテスト方針につ�
 
 - [JUnit :material-open-in-new:](https://junit.org/){ target=_blank }
     - Java のテストフレームワークです。
-- [Spring Test :material-open-in-new:](https://spring.pleiades.io/spring-framework/docs/current/reference/html/testing.html){ target=_blank }
+- [Spring Test :material-open-in-new:](https://spring.pleiades.io/spring-framework/reference/testing.html){ target=_blank }
     - Spring で構築したアプリケーションのテストを実行するためのツールセットです。
     - 主に Spring Boot アプリケーションのランタイムを結合テスト用に初期化するため使用します。
 - [H2 :material-open-in-new:](https://www.h2database.com/){ target=_blank }
@@ -40,7 +40,7 @@ description: バックエンドアプリケーションのテスト方針につ�
 
 AlesInfiny Maia の CSR 方式のバックエンドアプリケーションは、 Spring Boot を用いた Web API のアプリケーションです。
 結合テストでは、 Web API のリクエストを疑似的に再現し、アプリケーションの実行とレスポンスの検証します。
-Web API のリクエスト送信は、 Spring Test の [MockMvc :material-open-in-new:](https://spring.pleiades.io/spring-framework/docs/current/reference/html/testing.html#spring-mvc-test-framework){ target=_blank } を活用します。
+Web API のリクエスト送信は、 Spring Test の [MockMvc :material-open-in-new:](https://spring.pleiades.io/spring-framework/reference/testing/mockmvc.html){ target=_blank } を活用します。
 テストフレームワークは JUnit を利用します。
 
 テストが実行環境に依存しないように、データベースはインメモリの H2 を利用します。

--- a/documents/contents/app-architecture/client-side-rendering/test/backend-application/unit-test.md
+++ b/documents/contents/app-architecture/client-side-rendering/test/backend-application/unit-test.md
@@ -49,7 +49,7 @@ IDE および CI ツールを利用して、自動的に各ツールによるテ
 
 - [JUnit :material-open-in-new:](https://junit.org/){ target=_blank }
     - Java のテストフレームワークです。
-- [Spring Test :material-open-in-new:](https://spring.pleiades.io/spring-framework/docs/current/reference/html/testing.html){ target=_blank }
+- [Spring Test :material-open-in-new:](https://spring.pleiades.io/spring-framework/reference/testing.html){ target=_blank }
     - Spring で構築したアプリケーションのテストを実行するためのツールセットです。
     - 主にモックの作成に使用します。
 

--- a/documents/contents/guidebooks/how-to-develop/java/sub-project-settings/batch-project-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/java/sub-project-settings/batch-project-settings.md
@@ -54,8 +54,8 @@ batch プロジェクトに関する Spring Boot のプロパティ等を設定�
 batch プロジェクトの `src/main/resource` 以下に `application.properties` もしくは `application.yaml` ファイルを作成して行います。
 設定できる項目については、以下を参照してください。
 
-- [Spring Boot のアプリケーションプロパティ設定一覧 :material-open-in-new:](https://spring.pleiades.io/spring-boot/docs/current/reference/html/application-properties.html){ target=_blank }
-- [本番対応機能 :material-open-in-new:](https://spring.pleiades.io/spring-boot/docs/current/reference/html/actuator.html){ target=_blank }
+- [Spring Boot のアプリケーションプロパティ設定一覧 :material-open-in-new:](https://spring.pleiades.io/spring-boot/appendix/application-properties/){ target=_blank }
+- [本番対応機能 :material-open-in-new:](https://spring.pleiades.io/spring-boot/reference/actuator/){ target=_blank }
 - [myBatis-spring-boot-starter のアプリケーションプロパティ設定一覧 :material-open-in-new:](https://mybatis.org/spring-boot-starter/mybatis-spring-boot-autoconfigure/#configuration){ target=_blank }
 
 設定項目は多岐に渡るため、一般的に設定する項目について例示します。

--- a/documents/contents/guidebooks/how-to-develop/java/sub-project-settings/web-project-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/java/sub-project-settings/web-project-settings.md
@@ -61,8 +61,8 @@ web プロジェクトに関する Spring Boot のプロパティ等を設定し
 web プロジェクトの `src/main/resource` 以下に `application.properties` もしくは `application.yaml` ファイルを作成して行います。
 設定できる項目については、以下を参照してください。
 
-- [Spring Boot のアプリケーションプロパティ設定一覧 :material-open-in-new:](https://spring.pleiades.io/spring-boot/docs/current/reference/html/application-properties.html){ target=_blank }
-- [本番対応機能 :material-open-in-new:](https://spring.pleiades.io/spring-boot/docs/current/reference/html/actuator.html){ target=_blank }
+- [Spring Boot のアプリケーションプロパティ設定一覧 :material-open-in-new:](https://spring.pleiades.io/spring-boot/appendix/application-properties/){ target=_blank }
+- [本番対応機能 :material-open-in-new:](https://spring.pleiades.io/spring-boot/reference/actuator/){ target=_blank }
 - [myBatis-spring-boot-starter のアプリケーションプロパティ設定一覧 :material-open-in-new:](https://mybatis.org/spring-boot-starter/mybatis-spring-boot-autoconfigure/#configuration){ target=_blank }
 
 設定項目は多岐に渡るため、一般的に設定する項目について例示します。


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

Spring 関連のドキュメントについて、リンク先が古くなっており、想定していないページにリダイレクトしているものがあるため、該当箇所の URL を最新化しました。
    - docs/current/reference を URL に含むページの URL 体系が変わり、 詳細なページではなく全体の目次用のページにリダイレクトされているように見えるので、詳細なページにリンクするように修正しています。

### 確認してほしい点

- [ ] 修正箇所のリンク先が、ドキュメントの文脈上正しいものになっていること

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->