### PR TITLE
複合アクションへの setup-node のアップデート反映漏れを修正

### DIFF
--- a/.github/workflows/lint-documents/action.yml
+++ b/.github/workflows/lint-documents/action.yml
@@ -5,11 +5,11 @@ runs:
   using: "composite"
   steps:
     - name: Node.js のセットアップ
-      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8  # v4.0.2
+      uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v6.0.0
       with:
         node-version: lts/*
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
+        cache: npm
     - name: npm パッケージのインストール
       shell: bash
       run: npm ci


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

複合アクションに対して setup-node のアップデートが反映されていなかったため、反映しました。

2回目のワークフローの実行時にキャッシュヒットのログが出力されていることを確認しました。
```
Cache hit for: node-cache-Linux-x64-npm-2f073ad1863b6da7fc6da7ae484aacaf3b03eb853d117b4febebc5900ed0e351
```


## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->