### PR TITLE
ビルドスクリプトの警告を抑制するオプションを追加

### DIFF
--- a/samples/dressca-cms/web/src/main/resources/static/bootstrap/package.json
+++ b/samples/dressca-cms/web/src/main/resources/static/bootstrap/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build-sass": "npx sass ../scss/style.scss ../css/style.css"
+    "build-sass": "npx sass ../scss/style.scss ../css/style.css --silence-deprecation=import --silence-deprecation=global-builtin --silence-deprecation=color-functions"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

MPAのBootstrapにプライマリーカラーの変更などをうわっかぶせするビルドスクリプトにおいて、Bootstrapの内部実装に由来するDart Sassの警告を抑制するオプションを追加しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #3712

<!-- I want to review in Japanese. -->