### PR TITLE
Microsoft Entra External ID サンプルの npm/gradle パッケージを dependabot で監視するように構成

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -122,7 +122,7 @@ updates:
       default-days: 7
     open-pull-requests-limit: 20
     commit-message:
-      prefix: "gradle-external-id-auth-backend"
+      prefix: "gradle-external-id-for-spa"
     labels:
       - "target: EntraID External ID"
       - "gradle"


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

- External ID サンプルの npm / gradle パッケージを dependabot で監視するように設定しました。
- 設定値は AzureADB2C Auth に合わせました。
- 「cooldown」を cspell の無視リストに追加しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->　