### PR TITLE
Checkstyle for Javaを利用する時に.vscodeフォルダーおよびsettings.jsonがない場合の対応方法を追記

### DIFF
--- a/documents/contents/guidebooks/how-to-develop/csr/java/common-project-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/csr/java/common-project-settings.md
@@ -198,8 +198,8 @@ Checkstyle プラグインのその他の設定項目については、[こち�
     ```
 
 VS Code の拡張機能である [Checkstyle for Java](https://marketplace.visualstudio.com/items?itemName=shengchen.vscode-checkstyle) を利用している場合、 Checkstyle プラグインに適用したルールを Checkstyle for Java にも適用します。
-ルートディレクトリ直下の .vscode フォルダーの settings.json に設定を追記します。
-.vscode フォルダーおよび settings.json がない場合は新規作成してください。
+ルートディレクトリ直下の .vscode フォルダーの `settings.json` に設定を追記します。
+.vscode フォルダーおよび `settings.json` がない場合は新規作成してください。
 
 ```json
 {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

ガイドのJava編において、Checkstyle for Javaを利用する時に.vscodeフォルダーおよびsettings.jsonがない場合、新規作成をする旨を追記しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #3970

<!-- I want to review in Japanese. -->