### PR TITLE
ロギングライブラリの除外設定で設定先のファイルが build.gradle であることを明示

### DIFF
--- a/documents/contents/guidebooks/how-to-develop/csr/java/sub-project-settings/web-project-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/csr/java/sub-project-settings/web-project-settings.md
@@ -121,7 +121,7 @@ web プロジェクトの `src/main/resource` 以下に `application.properties`
 AlesInfiny Maia OSS Edition では、ロギングライブラリとして log4j2 を使用します。
 そのため、以下のようにデフォルトのロギングライブラリを依存関係から除外する設定を記述します。
 
-```groovy title="spring-boot-starter-logging の除外設定"
+```groovy title="web/build.gradle"
 configurations {
  all {
   exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

ガイドのjava編において、ロギングライブラリの除外設定で設定先のファイルが build.gradle であることを明示しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #3973

<!-- I want to review in Japanese. -->