### PR TITLE
機能モジュールのプロジェクトの設定において削除するクラス名を汎用化する

### DIFF
--- a/documents/contents/guidebooks/how-to-develop/ssr/java/sub-project-settings/function-module-project-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/ssr/java/sub-project-settings/function-module-project-settings.md
@@ -77,7 +77,7 @@ jar {
 ```
 
 また、併せて不要なファイルを削除します。
-a-function プロジェクトの `src` 以下にある、 `AFunctionApplication.java` と `AFunctionApplicationTest.java` を削除してください。
+機能モジュールプロジェクトの `src` 以下にある、アプリケーション起動クラス（`{機能モジュール名}Application.java`）とテストクラス（`{機能モジュール名}ApplicationTest.java`）を削除してください。
 
 ここまでを実行した後に、適切にビルドが実行できるかを確認します。
 ターミナルを用いてルートプロジェクト直下で以下を実行してください。


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

機能モジュールのプロジェクトの設定において削除するクラス名を汎用化しました。

## この Pull request では実施していないこと

別PR（ #4063 ）において、必要なスターターをAlesInfiny Maia のサンプルアプリの実態と合わせ、必要なライブラリを明確化しました。
各サブプロジェクトの下部に`build.gradle`の全量の例を示しているため下記には対応していませんが、対応が必要であればコメントいただきたいです。
```txt
1. dependencies の設定について、デフォルトで入っているやつは削除してしまって問題ないことを明示してほしい
```

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #3975 

<!-- I want to review in Japanese. -->