### PR TITLE
Adminのメールアドレス入力フォームのバリデーションメッセージを日本語化する

### DIFF
--- a/samples/web-csr/dressca-frontend/admin/src/validation/validation-items.ts
+++ b/samples/web-csr/dressca-frontend/admin/src/validation/validation-items.ts
@@ -4,7 +4,7 @@ import type { TypedSchema } from 'vee-validate'
 
 // バリデーション定義（一元化）
 export const validationItems = {
-  email: yup.string().email(),
+  email: yup.string().email('メールアドレスの形式で入力してください。'),
 }
 
 /**


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

Adminのメールアドレス入力フォームのバリデーションメッセージが未定義のため、
デフォルトの英語のメッセージが表示されていたため、日本語化しました。

## この Pull request では実施していないこと
この PR では不具合のある動作のみを修正し、下記の内容は考慮しません。

- https://github.com/AlesInfiny/maris/issues/1643
- https://github.com/AlesInfiny/maia/issues/2117

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->