### PR TITLE
自動生成されるクライアントコードについて再帰的に Prettier の対象外とするように設定を修正する

### DIFF
--- a/samples/azure-ad-b2c-sample/auth-frontend/app/.prettierignore
+++ b/samples/azure-ad-b2c-sample/auth-frontend/app/.prettierignore
@@ -29,6 +29,6 @@ coverage
 *.sw?
 
 # 自動生成されるファイル
-src/generated/*
+src/generated/**
 **/mockServiceWorker.js
 openapitools.json

--- a/samples/external-id-sample-for-spa/auth-frontend/app/.prettierignore
+++ b/samples/external-id-sample-for-spa/auth-frontend/app/.prettierignore
@@ -27,6 +27,6 @@ coverage
 *.tsbuildinfo
 
 # 自動生成されるファイル
-src/generated/*
+src/generated/**
 **/mockServiceWorker.js
 openapitools.json


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

自動生成されるクライアントコードに対し、
generated 配下のディレクトリすべてについて再帰的に Prettier の対象外とするように設定を修正しました。

修正前の実行ログを確認したところ、
.prettierignore の記法の仕様が理由と思われますが、元々 generated 配下は prettier の実行対象外になっていたので、不具合⇒内部の改善 にラベルを移動しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->