### PR TITLE
ApplicationContextWrapperの読み込みエラーによってテストが落ちる事象に対応

### DIFF
--- a/samples/web-csr/dressca-backend/application-core/src/test/java/com/dressca/applicationcore/applicationservice/AssetApplicationServiceTest.java
+++ b/samples/web-csr/dressca-backend/application-core/src/test/java/com/dressca/applicationcore/applicationservice/AssetApplicationServiceTest.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.context.MessageSourceAutoConfiguration;
 import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.TestPropertySource;
@@ -25,12 +26,14 @@ import com.dressca.applicationcore.assets.AssetNotFoundException;
 import com.dressca.applicationcore.assets.AssetRepository;
 import com.dressca.applicationcore.assets.AssetResourceInfo;
 import com.dressca.applicationcore.assets.AssetStore;
+import com.dressca.applicationcore.config.ApplicationCoreTestConfig;
 import com.dressca.systemcommon.log.AbstractStructuredLogger;
 
 /**
  * {@link AssetApplicationService}の動作をテストするクラスです。
  */
-@ExtendWith({ SpringExtension.class, MockitoExtension.class })
+@Import(ApplicationCoreTestConfig.class)
+@ExtendWith({SpringExtension.class, MockitoExtension.class})
 @TestPropertySource(properties = "spring.messages.basename=applicationcore.messages")
 @ImportAutoConfiguration(MessageSourceAutoConfiguration.class)
 public class AssetApplicationServiceTest {

--- a/samples/web-csr/dressca-backend/application-core/src/test/java/com/dressca/applicationcore/applicationservice/CatalogApplicationServiceTest.java
+++ b/samples/web-csr/dressca-backend/application-core/src/test/java/com/dressca/applicationcore/applicationservice/CatalogApplicationServiceTest.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.context.MessageSourceAutoConfiguration;
 import org.springframework.context.MessageSource;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import com.dressca.applicationcore.authorization.PermissionDeniedException;
 import com.dressca.applicationcore.authorization.UserStore;
@@ -41,12 +42,14 @@ import com.dressca.applicationcore.catalog.CatalogItem;
 import com.dressca.applicationcore.catalog.CatalogNotFoundException;
 import com.dressca.applicationcore.catalog.CatalogRepository;
 import com.dressca.applicationcore.catalog.OptimisticLockingFailureException;
+import com.dressca.applicationcore.config.ApplicationCoreTestConfig;
 import com.dressca.systemcommon.log.AbstractStructuredLogger;
 
 /**
  * {@link CatalogApplicationService}の動作をテストするクラスです。
  */
-@ExtendWith({ SpringExtension.class, MockitoExtension.class })
+@Import(ApplicationCoreTestConfig.class)
+@ExtendWith({SpringExtension.class, MockitoExtension.class})
 @TestPropertySource(properties = "spring.messages.basename=applicationcore.messages")
 @ImportAutoConfiguration(MessageSourceAutoConfiguration.class)
 public class CatalogApplicationServiceTest {

--- a/samples/web-csr/dressca-backend/application-core/src/test/java/com/dressca/applicationcore/applicationservice/OrderApplicationServiceTest.java
+++ b/samples/web-csr/dressca-backend/application-core/src/test/java/com/dressca/applicationcore/applicationservice/OrderApplicationServiceTest.java
@@ -8,6 +8,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import com.dressca.applicationcore.config.ApplicationCoreTestConfig;
 import com.dressca.applicationcore.order.Address;
 import com.dressca.applicationcore.order.CatalogItemOrdered;
 import com.dressca.applicationcore.order.Order;
@@ -27,12 +28,14 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.context.MessageSourceAutoConfiguration;
 import org.springframework.context.MessageSource;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * {@link OrderApplicationService}の動作をテストするクラスです。
  */
-@ExtendWith({ SpringExtension.class, MockitoExtension.class })
+@Import(ApplicationCoreTestConfig.class)
+@ExtendWith({SpringExtension.class, MockitoExtension.class})
 @TestPropertySource(properties = "spring.messages.basename=applicationcore.messages")
 @ImportAutoConfiguration(MessageSourceAutoConfiguration.class)
 public class OrderApplicationServiceTest {

--- a/samples/web-csr/dressca-backend/application-core/src/test/java/com/dressca/applicationcore/applicationservice/ShoppingApplicationServiceTest.java
+++ b/samples/web-csr/dressca-backend/application-core/src/test/java/com/dressca/applicationcore/applicationservice/ShoppingApplicationServiceTest.java
@@ -30,6 +30,7 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.context.MessageSourceAutoConfiguration;
 import org.springframework.context.MessageSource;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import com.dressca.applicationcore.baskets.Basket;
 import com.dressca.applicationcore.baskets.BasketNotFoundException;
@@ -39,6 +40,7 @@ import com.dressca.applicationcore.catalog.CatalogDomainService;
 import com.dressca.applicationcore.catalog.CatalogItem;
 import com.dressca.applicationcore.catalog.CatalogNotFoundException;
 import com.dressca.applicationcore.catalog.CatalogRepository;
+import com.dressca.applicationcore.config.ApplicationCoreTestConfig;
 import com.dressca.applicationcore.order.Address;
 import com.dressca.applicationcore.order.CatalogItemOrdered;
 import com.dressca.applicationcore.order.EmptyBasketOnCheckoutException;
@@ -51,7 +53,8 @@ import com.dressca.systemcommon.log.AbstractStructuredLogger;
 /**
  * {@link ShoppingApplicationService}の動作をテストするクラスです。
  */
-@ExtendWith({ SpringExtension.class, MockitoExtension.class })
+@ExtendWith({SpringExtension.class, MockitoExtension.class})
+@Import(ApplicationCoreTestConfig.class)
 @TestPropertySource(properties = "spring.messages.basename=applicationcore.messages")
 @ImportAutoConfiguration(MessageSourceAutoConfiguration.class)
 public class ShoppingApplicationServiceTest {

--- a/samples/web-csr/dressca-backend/application-core/src/test/java/com/dressca/applicationcore/catalog/CatalogDomainServiceTest.java
+++ b/samples/web-csr/dressca-backend/application-core/src/test/java/com/dressca/applicationcore/catalog/CatalogDomainServiceTest.java
@@ -16,12 +16,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import com.dressca.applicationcore.config.ApplicationCoreTestConfig;
 
 /**
  * {@link CatalogDomainService}の動作をテストするクラスです。
  */
-@ExtendWith({ SpringExtension.class, MockitoExtension.class })
+@ExtendWith({SpringExtension.class, MockitoExtension.class})
+@Import(ApplicationCoreTestConfig.class)
 public class CatalogDomainServiceTest {
   @Mock
   private CatalogRepository catalogRepository;

--- a/samples/web-csr/dressca-backend/application-core/src/test/java/com/dressca/applicationcore/config/ApplicationCoreTestConfig.java
+++ b/samples/web-csr/dressca-backend/application-core/src/test/java/com/dressca/applicationcore/config/ApplicationCoreTestConfig.java
@@ -11,7 +11,7 @@ import com.dressca.systemcommon.util.ApplicationContextWrapper;
 @TestConfiguration
 public class ApplicationCoreTestConfig {
   @Bean
-  ApplicationContextWrapper applicationContextWrapper() {
+  public ApplicationContextWrapper applicationContextWrapper() {
     return new ApplicationContextWrapper();
   }
 }

--- a/samples/web-csr/dressca-backend/application-core/src/test/java/com/dressca/applicationcore/config/ApplicationCoreTestConfig.java
+++ b/samples/web-csr/dressca-backend/application-core/src/test/java/com/dressca/applicationcore/config/ApplicationCoreTestConfig.java
@@ -10,6 +10,9 @@ import com.dressca.systemcommon.util.ApplicationContextWrapper;
  */
 @TestConfiguration
 public class ApplicationCoreTestConfig {
+  /**
+   * テスト用に {@link ApplicationContextWrapper} を Bean として登録します。
+   */
   @Bean
   public ApplicationContextWrapper applicationContextWrapper() {
     return new ApplicationContextWrapper();

--- a/samples/web-csr/dressca-backend/application-core/src/test/java/com/dressca/applicationcore/config/ApplicationCoreTestConfig.java
+++ b/samples/web-csr/dressca-backend/application-core/src/test/java/com/dressca/applicationcore/config/ApplicationCoreTestConfig.java
@@ -1,0 +1,17 @@
+package com.dressca.applicationcore.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import com.dressca.systemcommon.util.ApplicationContextWrapper;
+
+/**
+ * アプリケーションコア層のテスト用設定クラスです。
+ * テスト用の Bean 定義などを記述します。
+ */
+@TestConfiguration
+public class ApplicationCoreTestConfig {
+  @Bean
+  ApplicationContextWrapper applicationContextWrapper() {
+    return new ApplicationContextWrapper();
+  }
+}


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

以下のPRにて、業務例外とシステム例外がApplicationContextWrapperに依存するようになりました。
- https://github.com/AlesInfiny/maia/pull/4441

現在のアプリケーションコア層のテストクラスでは、ApplicationContextWrapperがBean登録されずにテストが走るため、異常系のテストでApplicationContextWrapperがnullになり、テストが落ちます。
これに対応するため、本PRでは、アプリケーションコア層のテストに設定クラスを配置し、ApplicationContextWrapperクラスをBean登録しました。

## この Pull request では実施していないこと

PR作成時のCIでテストが失敗するにも関わらず、Jobが成功する事象については原因不明で本PRでは対応しておりません。

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #4441 

<!-- I want to review in Japanese. -->