### PR TITLE
VS Code 拡張機能のCheckstyleのバージョンを13.0.0から13.4.0に更新

### DIFF
--- a/samples/azure-ad-b2c-sample/auth-backend/.vscode/settings.json
+++ b/samples/azure-ad-b2c-sample/auth-backend/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "java.dependency.packagePresentation": "hierarchical",
   "java.configuration.updateBuildConfiguration": "automatic",
-  "java.checkstyle.version": "13.0.0",
+  "java.checkstyle.version": "13.4.0",
   "java.checkstyle.configuration": "${workspaceFolder}/config/checkstyle/checkstyle.xml",
   "java.checkstyle.properties": {
     "config_loc": "${workspaceFolder}/config/checkstyle"

--- a/samples/dressca-cms/.vscode/settings.json
+++ b/samples/dressca-cms/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "java.dependency.packagePresentation": "hierarchical",
   "java.configuration.updateBuildConfiguration": "automatic",
-  "java.checkstyle.version": "13.0.0",
+  "java.checkstyle.version": "13.4.0",
   "java.checkstyle.configuration": "${workspaceFolder}/config/checkstyle/checkstyle.xml",
   "java.checkstyle.properties": {
     "config_loc": "${workspaceFolder}/config/checkstyle"

--- a/samples/external-id-sample-for-spa/auth-backend/.vscode/settings.json
+++ b/samples/external-id-sample-for-spa/auth-backend/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "java.dependency.packagePresentation": "hierarchical",
   "java.configuration.updateBuildConfiguration": "automatic",
-  "java.checkstyle.version": "13.0.0",
+  "java.checkstyle.version": "13.4.0",
   "java.checkstyle.configuration": "${workspaceFolder}/config/checkstyle/checkstyle.xml",
   "java.checkstyle.properties": {
     "config_loc": "${workspaceFolder}/config/checkstyle"

--- a/samples/web-csr/dressca-backend/.vscode/settings.json
+++ b/samples/web-csr/dressca-backend/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "java.dependency.packagePresentation": "hierarchical",
   "java.configuration.updateBuildConfiguration": "automatic",
-  "java.checkstyle.version": "13.0.0",
+  "java.checkstyle.version": "13.4.0",
   "java.checkstyle.configuration": "${workspaceFolder}/config/checkstyle/checkstyle.xml",
   "java.checkstyle.properties": {
     "config_loc": "${workspaceFolder}/config/checkstyle"


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

VS Code 拡張機能のCheckstyleのバージョンを13.0.0から13.4.0に更新しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #4594 

<!-- I want to review in Japanese. -->