### PR TITLE
買い物かごアイテムの数量更新失敗時に画面上の数値のみ更新される問題に対応

### DIFF
--- a/samples/web-csr/dressca-frontend/consumer/src/components/__tests__/BasketItem.spec.ts
+++ b/samples/web-csr/dressca-frontend/consumer/src/components/__tests__/BasketItem.spec.ts
@@ -27,10 +27,11 @@ describe('BasketItem', () => {
     // Arrange
     const basketItemResponse = createBasketItemResponse()
     const available = true
+    const isSubmitting = false
 
     // Act
     const wrapper = mount(BasketItem, {
-      props: { item: basketItemResponse, available },
+      props: { item: basketItemResponse, available, submitting: isSubmitting },
       global: { plugins: [i18n] },
     })
 
@@ -42,10 +43,11 @@ describe('BasketItem', () => {
     // Arrange
     const basketItemResponse = createBasketItemResponse()
     const available = true
+    const isSubmitting = false
 
     // Act
     const wrapper = mount(BasketItem, {
-      props: { item: basketItemResponse, available },
+      props: { item: basketItemResponse, available, submitting: isSubmitting },
       global: { plugins: [i18n] },
     })
 
@@ -57,10 +59,11 @@ describe('BasketItem', () => {
     // Arrange
     const basketItemResponse = createBasketItemResponse()
     const available = false
+    const isSubmitting = false
 
     // Act
     const wrapper = mount(BasketItem, {
-      props: { item: basketItemResponse, available },
+      props: { item: basketItemResponse, available, submitting: isSubmitting },
       global: { plugins: [i18n] },
     })
 

--- a/samples/web-csr/dressca-frontend/consumer/src/components/basket/BasketItem.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/components/basket/BasketItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, watch } from 'vue'
 import type { BasketItemResponse } from '@/generated/api-client/models/basket-item-response'
 import { TrashIcon } from '@heroicons/vue/24/outline'
 import * as yup from 'yup'
@@ -12,6 +12,7 @@ const { t } = i18n.global
 const props = defineProps<{
   item: BasketItemResponse
   available: boolean
+  submitting: boolean
 }>()
 
 const emit = defineEmits<{
@@ -33,30 +34,25 @@ const { toCurrencyJPY } = currencyHelper()
 const { getFirstAssetUrl } = assetHelper()
 
 const isUpdateDisabled = computed(() => !(meta.value.valid && meta.value.dirty))
-// 更新・削除処理の多重実行を防止するためのフラグです。
-const isSubmitting = ref(false)
 
 watch(
   () => props.item,
   (item) => {
-    isSubmitting.value = false
     resetForm({ values: { quantity: item.quantity } })
   },
 )
 
 const update = () => {
-  if (isSubmitting.value) {
+  if (props.submitting) {
     return
   }
-  isSubmitting.value = true
   emit('update', props.item.catalogItemId, quantity.value)
 }
 
 const remove = () => {
-  if (isSubmitting.value) {
+  if (props.submitting) {
     return
   }
-  isSubmitting.value = true
   emit('remove', props.item.catalogItemId)
 }
 </script>

--- a/samples/web-csr/dressca-frontend/consumer/src/components/basket/BasketItem.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/components/basket/BasketItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import type { BasketItemResponse } from '@/generated/api-client/models/basket-item-response'
 import { TrashIcon } from '@heroicons/vue/24/outline'
 import * as yup from 'yup'
@@ -32,22 +32,31 @@ const { value: quantity } = useField<number>('quantity')
 const { toCurrencyJPY } = currencyHelper()
 const { getFirstAssetUrl } = assetHelper()
 
-const isUpdateDisabled = computed(() => !props.available || !(meta.value.valid && meta.value.dirty))
+const isUpdateDisabled = computed(() => !(meta.value.valid && meta.value.dirty))
+// 更新・削除処理の多重実行を防止するためのフラグです。
+const isSubmitting = ref(false)
 
 watch(
   () => props.item,
   (item) => {
+    isSubmitting.value = false
     resetForm({ values: { quantity: item.quantity } })
   },
 )
 
 const update = () => {
-  resetForm({ values: { quantity: quantity.value } })
+  if (isSubmitting.value) {
+    return
+  }
+  isSubmitting.value = true
   emit('update', props.item.catalogItemId, quantity.value)
 }
 
 const remove = () => {
-  resetForm({ values: { quantity: props.item.quantity } })
+  if (isSubmitting.value) {
+    return
+  }
+  isSubmitting.value = true
   emit('remove', props.item.catalogItemId)
 }
 </script>

--- a/samples/web-csr/dressca-frontend/consumer/src/components/basket/BasketItem.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/components/basket/BasketItem.vue
@@ -42,10 +42,12 @@ watch(
 )
 
 const update = () => {
+  resetForm({ values: { quantity: quantity.value } })
   emit('update', props.item.catalogItemId, quantity.value)
 }
 
 const remove = () => {
+  resetForm({ values: { quantity: props.item.quantity } })
   emit('remove', props.item.catalogItemId)
 }
 </script>

--- a/samples/web-csr/dressca-frontend/consumer/src/components/basket/BasketItem.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/components/basket/BasketItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import type { BasketItemResponse } from '@/generated/api-client/models/basket-item-response'
 import { TrashIcon } from '@heroicons/vue/24/outline'
 import * as yup from 'yup'
@@ -32,15 +32,20 @@ const { value: quantity } = useField<number>('quantity')
 const { toCurrencyJPY } = currencyHelper()
 const { getFirstAssetUrl } = assetHelper()
 
-const isUpdateDisabled = computed(() => !(meta.value.valid && meta.value.dirty))
+const isUpdateDisabled = computed(() => !props.available || !(meta.value.valid && meta.value.dirty))
+
+watch(
+  () => props.item,
+  (item) => {
+    resetForm({ values: { quantity: item.quantity } })
+  },
+)
 
 const update = () => {
-  resetForm({ values: { quantity: quantity.value } })
   emit('update', props.item.catalogItemId, quantity.value)
 }
 
 const remove = () => {
-  resetForm({ values: { quantity: props.item.quantity } })
   emit('remove', props.item.catalogItemId)
 }
 </script>

--- a/samples/web-csr/dressca-frontend/consumer/src/views/basket/BasketView.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/basket/BasketView.vue
@@ -29,6 +29,9 @@ const { toCurrencyJPY } = currencyHelper()
 const { getFirstAssetUrl } = assetHelper()
 const { t } = i18n.global
 
+// アイテムの更新・削除を二重実行させないためのフラグ
+const isSubmitting = ref(false)
+
 const isEmpty = () => {
   return getBasket.value.basketItems?.length === 0
 }
@@ -38,6 +41,11 @@ const goCatalog = () => {
 }
 
 const update = async (catalogItemId: number, newQuantity: number) => {
+  if (isSubmitting.value) {
+    return
+  }
+
+  isSubmitting.value = true
   try {
     await updateItemInBasket(catalogItemId, newQuantity)
   } catch (error) {
@@ -63,11 +71,18 @@ const update = async (catalogItemId: number, newQuantity: number) => {
         }
       },
     )
+  } finally {
+    isSubmitting.value = false
   }
 }
 
 // 削除に失敗した通知を出す
 const remove = async (catalogItemId: number) => {
+  if (isSubmitting.value) {
+    return
+  }
+
+  isSubmitting.value = true
   try {
     await removeItemFromBasket(catalogItemId)
   } catch (error) {
@@ -93,6 +108,8 @@ const remove = async (catalogItemId: number) => {
         }
       },
     )
+  } finally {
+    isSubmitting.value = false
   }
 }
 
@@ -188,6 +205,7 @@ onUnmounted(() => basketStore.deleteAddedItemId())
           <BasketItem
             :item="item"
             :available="!getDeletedItemIds.includes(item.catalogItemId)"
+            :submitting="isSubmitting"
             @update="update"
             @remove="remove"
           ></BasketItem>

--- a/samples/web-csr/dressca-frontend/consumer/src/views/basket/BasketView.vue
+++ b/samples/web-csr/dressca-frontend/consumer/src/views/basket/BasketView.vue
@@ -29,7 +29,7 @@ const { toCurrencyJPY } = currencyHelper()
 const { getFirstAssetUrl } = assetHelper()
 const { t } = i18n.global
 
-// アイテムの更新・削除を二重実行させないためのフラグ
+// アイテムの更新・削除を二重実行させないためのフラグです。
 const isSubmitting = ref(false)
 
 const isEmpty = () => {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

買い物かご画面において、カタログから削除済みのアイテムの数量更新を試みると、400エラーが発生します。
そのため、DB上は買い物かごのアイテム数量は更新されませんが、UI上は数量は更新されません。

mainブランチにおいて、以下の手順で再現できます。

- consumerアプリで任意のアイテムを買い物かごに追加します。
- adminアプリで買い物かごに追加したアイテムを削除します。
- consumerアプリで先ほど追加したアイテムの数量を1から2に更新します。
- すると、データベースとpiniaのストアでは１個のままですが、見た目上は2個になり、データベースとUIの不整合が発生します。

本PRは、買い物かごアイテムのコンポーネントにwatch式を追加して、買い物かごアイテムの状態が変化した際にフォームをリセットするようにしました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #2101 

<!-- I want to review in Japanese. -->