### PR TITLE
集約例外ハンドラーの利用されていないメソッド引数を削除

### DIFF
--- a/samples/azure-ad-b2c-sample/auth-backend/web/src/main/java/com/dressca/web/controller/advice/ExceptionHandlerControllerAdvice.java
+++ b/samples/azure-ad-b2c-sample/auth-backend/web/src/main/java/com/dressca/web/controller/advice/ExceptionHandlerControllerAdvice.java
@@ -1,6 +1,5 @@
 package com.dressca.web.controller.advice;
 
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import com.dressca.systemcommon.constant.CommonExceptionIdConstants;
 import com.dressca.systemcommon.log.AbstractStructuredLogger;
@@ -24,17 +23,14 @@ public class ExceptionHandlerControllerAdvice extends ResponseEntityExceptionHan
   private final AbstractStructuredLogger apLog;
   private final ProblemDetailsFactory problemDetailsFactory;
 
-
   /**
    * 未認証の例外をステータースコード 401 で返却します。
    *
    * @param e 未認証の例外。
-   * @param req リクエスト。
    * @return ステータースコード 401 のレスポンス。
    */
   @ExceptionHandler(AccessDeniedException.class)
-  public ResponseEntity<ProblemDetail> accessDeniedHandleException(AccessDeniedException e,
-      HttpServletRequest req) {
+  public ResponseEntity<ProblemDetail> accessDeniedHandleException(AccessDeniedException e) {
     ErrorMessageBuilder errorBuilder =
         new ErrorMessageBuilder(e, CommonExceptionIdConstants.E_UNAUTHORIZED, null, null);
     apLog.error(errorBuilder.createLogMessageStackTrace());
@@ -48,11 +44,10 @@ public class ExceptionHandlerControllerAdvice extends ResponseEntityExceptionHan
    * その他の例外をステータースコード 500 で返却します。
    *
    * @param e その他の例外。
-   * @param req リクエスト。
    * @return ステータースコード 500 のレスポンス。
    */
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<ProblemDetail> handleException(Exception e, HttpServletRequest req) {
+  public ResponseEntity<ProblemDetail> handleException(Exception e) {
     ErrorMessageBuilder errorBuilder =
         new ErrorMessageBuilder(e, CommonExceptionIdConstants.E_SYSTEM, null, null);
     apLog.error(errorBuilder.createLogMessageStackTrace());

--- a/samples/external-id-sample-for-spa/auth-backend/web/src/main/java/com/dressca/web/controller/advice/ExceptionHandlerControllerAdvice.java
+++ b/samples/external-id-sample-for-spa/auth-backend/web/src/main/java/com/dressca/web/controller/advice/ExceptionHandlerControllerAdvice.java
@@ -1,6 +1,5 @@
 package com.dressca.web.controller.advice;
 
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import com.dressca.systemcommon.constant.CommonExceptionIdConstants;
 import com.dressca.systemcommon.log.AbstractStructuredLogger;
@@ -27,12 +26,10 @@ public class ExceptionHandlerControllerAdvice extends ResponseEntityExceptionHan
    * 未認証の例外をステータースコード 401 で返却します。
    *
    * @param e 未認証の例外。
-   * @param req リクエスト。
    * @return ステータースコード 401 のレスポンス。
    */
   @ExceptionHandler(AccessDeniedException.class)
-  public ResponseEntity<ProblemDetail> accessDeniedHandleException(AccessDeniedException e,
-      HttpServletRequest req) {
+  public ResponseEntity<ProblemDetail> accessDeniedHandleException(AccessDeniedException e) {
     ErrorMessageBuilder errorBuilder =
         new ErrorMessageBuilder(e, CommonExceptionIdConstants.E_UNAUTHORIZED, null, null);
     apLog.error(errorBuilder.createLogMessageStackTrace());
@@ -46,11 +43,10 @@ public class ExceptionHandlerControllerAdvice extends ResponseEntityExceptionHan
    * その他の例外をステータースコード 500 で返却します。
    *
    * @param e その他の例外。
-   * @param req リクエスト。
    * @return ステータースコード 500 のレスポンス。
    */
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<ProblemDetail> handleException(Exception e, HttpServletRequest req) {
+  public ResponseEntity<ProblemDetail> handleException(Exception e) {
     ErrorMessageBuilder errorBuilder =
         new ErrorMessageBuilder(e, CommonExceptionIdConstants.E_SYSTEM, null, null);
     apLog.error(errorBuilder.createLogMessageStackTrace());

--- a/samples/web-csr/dressca-backend/web/src/main/java/com/dressca/web/controller/advice/ExceptionHandlerControllerAdvice.java
+++ b/samples/web-csr/dressca-backend/web/src/main/java/com/dressca/web/controller/advice/ExceptionHandlerControllerAdvice.java
@@ -49,7 +49,7 @@ public class ExceptionHandlerControllerAdvice extends ResponseEntityExceptionHan
    * @return ステータースコード 404 のレスポンス。
    */
   @ExceptionHandler({AuthorizationDeniedException.class, PermissionDeniedException.class})
-  public ResponseEntity<String> handleAuthorizationDeniedException(AuthorizationDeniedException e) {
+  public ResponseEntity<String> handleAuthorizationDeniedException(Exception e) {
     apLog.warn(ExceptionUtils.getStackTrace(e));
     return ResponseEntity.notFound().build();
   }

--- a/samples/web-csr/dressca-backend/web/src/main/java/com/dressca/web/controller/advice/ExceptionHandlerControllerAdvice.java
+++ b/samples/web-csr/dressca-backend/web/src/main/java/com/dressca/web/controller/advice/ExceptionHandlerControllerAdvice.java
@@ -1,6 +1,5 @@
 package com.dressca.web.controller.advice;
 
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import com.dressca.applicationcore.authorization.PermissionDeniedException;
 import com.dressca.applicationcore.catalog.OptimisticLockingFailureException;
@@ -34,12 +33,11 @@ public class ExceptionHandlerControllerAdvice extends ResponseEntityExceptionHan
    * 未認証エラーをステータスコード 401 で返却します。
    *
    * @param e 未認証エラー。
-   * @param req リクエスト。
    * @return ステータースコード 401 のレスポンス。
    */
   @ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
   public ResponseEntity<String> handleAuthenticationCredentialsNotFoundException(
-      AuthenticationCredentialsNotFoundException e, HttpServletRequest req) {
+      AuthenticationCredentialsNotFoundException e) {
     apLog.warn(ExceptionUtils.getStackTrace(e));
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
   }
@@ -48,12 +46,10 @@ public class ExceptionHandlerControllerAdvice extends ResponseEntityExceptionHan
    * 認可エラーをステータスコード 404 で返却します。
    *
    * @param e 認可エラー。
-   * @param req リクエスト。
    * @return ステータースコード 404 のレスポンス。
    */
   @ExceptionHandler({AuthorizationDeniedException.class, PermissionDeniedException.class})
-  public ResponseEntity<String> handleAuthorizationDeniedException(AuthorizationDeniedException e,
-      HttpServletRequest req) {
+  public ResponseEntity<String> handleAuthorizationDeniedException(AuthorizationDeniedException e) {
     apLog.warn(ExceptionUtils.getStackTrace(e));
     return ResponseEntity.notFound().build();
   }
@@ -62,12 +58,11 @@ public class ExceptionHandlerControllerAdvice extends ResponseEntityExceptionHan
    * 楽観ロックエラーをステータスコード 409 で返却します。
    * 
    * @param e 楽観ロックエラー。
-   * @param req リクエスト。
    * @return ステータスコード 409 のレスポンス。
    */
   @ExceptionHandler(OptimisticLockingFailureException.class)
   public ResponseEntity<String> handleOptimisticLockingFailureException(
-      OptimisticLockingFailureException e, HttpServletRequest req) {
+      OptimisticLockingFailureException e) {
     apLog.warn(ExceptionUtils.getStackTrace(e));
     return ResponseEntity.status(HttpStatus.CONFLICT).body(null);
   }
@@ -76,12 +71,10 @@ public class ExceptionHandlerControllerAdvice extends ResponseEntityExceptionHan
    * その他の業務エラーをステータースコード 500 で返却します。
    *
    * @param e 業務例外。
-   * @param req リクエスト。
    * @return ステータースコード 500 のレスポンス。
    */
   @ExceptionHandler(LogicException.class)
-  public ResponseEntity<ProblemDetail> handleLogicException(LogicException e,
-      HttpServletRequest req) {
+  public ResponseEntity<ProblemDetail> handleLogicException(LogicException e) {
     ErrorMessageBuilder errorBuilder =
         new ErrorMessageBuilder(e, CommonExceptionIdConstants.E_BUSINESS, null, null);
     apLog.error(errorBuilder.createLogMessageStackTrace());
@@ -95,12 +88,10 @@ public class ExceptionHandlerControllerAdvice extends ResponseEntityExceptionHan
    * その他のシステムエラーをステータースコード 500 で返却します。
    *
    * @param e その他の例外。
-   * @param req リクエスト。
    * @return ステータースコード 500 のレスポンス。
    */
   @ExceptionHandler(SystemException.class)
-  public ResponseEntity<ProblemDetail> handleSystemException(SystemException e,
-      HttpServletRequest req) {
+  public ResponseEntity<ProblemDetail> handleSystemException(SystemException e) {
     ErrorMessageBuilder errorBuilder =
         new ErrorMessageBuilder(e, CommonExceptionIdConstants.E_SYSTEM, null, null);
     apLog.error(errorBuilder.createLogMessageStackTrace());
@@ -114,11 +105,10 @@ public class ExceptionHandlerControllerAdvice extends ResponseEntityExceptionHan
    * 上記のいずれにも当てはまらない例外をステータースコード 500 で返却します。
    *
    * @param e その他の例外。
-   * @param req リクエスト。
    * @return ステータースコード 500 のレスポンス。
    */
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<ProblemDetail> handleException(Exception e, HttpServletRequest req) {
+  public ResponseEntity<ProblemDetail> handleException(Exception e) {
     ErrorMessageBuilder errorBuilder =
         new ErrorMessageBuilder(e, CommonExceptionIdConstants.E_SYSTEM, null, null);
     apLog.error(errorBuilder.createLogMessageStackTrace());

--- a/samples/web-csr/dressca-backend/web/src/main/java/com/dressca/web/controller/advice/LocalExceptionHandlerControllerAdvice.java
+++ b/samples/web-csr/dressca-backend/web/src/main/java/com/dressca/web/controller/advice/LocalExceptionHandlerControllerAdvice.java
@@ -49,7 +49,7 @@ public class LocalExceptionHandlerControllerAdvice extends ResponseEntityExcepti
    * @return ステータースコード 404 のレスポンス。
    */
   @ExceptionHandler({AuthorizationDeniedException.class, PermissionDeniedException.class})
-  public ResponseEntity<String> handleAuthorizationDeniedException(AuthorizationDeniedException e) {
+  public ResponseEntity<String> handleAuthorizationDeniedException(Exception e) {
     apLog.warn(ExceptionUtils.getStackTrace(e));
     return ResponseEntity.notFound().build();
   }

--- a/samples/web-csr/dressca-backend/web/src/main/java/com/dressca/web/controller/advice/LocalExceptionHandlerControllerAdvice.java
+++ b/samples/web-csr/dressca-backend/web/src/main/java/com/dressca/web/controller/advice/LocalExceptionHandlerControllerAdvice.java
@@ -1,6 +1,5 @@
 package com.dressca.web.controller.advice;
 
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import com.dressca.applicationcore.authorization.PermissionDeniedException;
 import com.dressca.applicationcore.catalog.OptimisticLockingFailureException;
@@ -34,12 +33,11 @@ public class LocalExceptionHandlerControllerAdvice extends ResponseEntityExcepti
    * 未認証エラーをステータスコード 401 で返却します。
    *
    * @param e 未認証エラー。
-   * @param req リクエスト。
    * @return ステータースコード 401 のレスポンス。
    */
   @ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
   public ResponseEntity<String> handleAuthenticationCredentialsNotFoundException(
-      AuthenticationCredentialsNotFoundException e, HttpServletRequest req) {
+      AuthenticationCredentialsNotFoundException e) {
     apLog.warn(ExceptionUtils.getStackTrace(e));
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
   }
@@ -48,12 +46,10 @@ public class LocalExceptionHandlerControllerAdvice extends ResponseEntityExcepti
    * 認可エラーをステータスコード 404 で返却します。
    *
    * @param e 認可エラー。
-   * @param req リクエスト。
    * @return ステータースコード 404 のレスポンス。
    */
   @ExceptionHandler({AuthorizationDeniedException.class, PermissionDeniedException.class})
-  public ResponseEntity<String> handleAuthorizationDeniedException(AuthorizationDeniedException e,
-      HttpServletRequest req) {
+  public ResponseEntity<String> handleAuthorizationDeniedException(AuthorizationDeniedException e) {
     apLog.warn(ExceptionUtils.getStackTrace(e));
     return ResponseEntity.notFound().build();
   }
@@ -62,12 +58,11 @@ public class LocalExceptionHandlerControllerAdvice extends ResponseEntityExcepti
    * 楽観ロックエラーをステータスコード 409 で返却します。
    * 
    * @param e 楽観ロックエラー。
-   * @param req リクエスト。
    * @return ステータスコード 409 のレスポンス。
    */
   @ExceptionHandler(OptimisticLockingFailureException.class)
   public ResponseEntity<String> handleOptimisticLockingFailureException(
-      OptimisticLockingFailureException e, HttpServletRequest req) {
+      OptimisticLockingFailureException e) {
     apLog.warn(ExceptionUtils.getStackTrace(e));
     return ResponseEntity.status(HttpStatus.CONFLICT).body(null);
   }
@@ -76,12 +71,10 @@ public class LocalExceptionHandlerControllerAdvice extends ResponseEntityExcepti
    * その他の業務エラーをステータースコード 500 で返却します。
    *
    * @param e 業務例外。
-   * @param req リクエスト。
    * @return ステータースコード 500 のレスポンス。
    */
   @ExceptionHandler(LogicException.class)
-  public ResponseEntity<ProblemDetail> handleLogicException(LogicException e,
-      HttpServletRequest req) {
+  public ResponseEntity<ProblemDetail> handleLogicException(LogicException e) {
     ErrorMessageBuilder errorBuilder =
         new ErrorMessageBuilder(e, CommonExceptionIdConstants.E_BUSINESS, null, null);
     apLog.error(errorBuilder.createLogMessageStackTrace());
@@ -95,12 +88,10 @@ public class LocalExceptionHandlerControllerAdvice extends ResponseEntityExcepti
    * その他のシステムエラーをステータースコード 500 で返却します。
    *
    * @param e その他の例外。
-   * @param req リクエスト。
    * @return ステータースコード 500 のレスポンス。
    */
   @ExceptionHandler(SystemException.class)
-  public ResponseEntity<ProblemDetail> handleSystemException(SystemException e,
-      HttpServletRequest req) {
+  public ResponseEntity<ProblemDetail> handleSystemException(SystemException e) {
     ErrorMessageBuilder errorBuilder =
         new ErrorMessageBuilder(e, CommonExceptionIdConstants.E_SYSTEM, null, null);
     apLog.error(errorBuilder.createLogMessageStackTrace());
@@ -114,11 +105,10 @@ public class LocalExceptionHandlerControllerAdvice extends ResponseEntityExcepti
    * 上記のいずれにも当てはまらない例外をステータースコード 500 で返却します。
    *
    * @param e その他の例外。
-   * @param req リクエスト。
    * @return ステータースコード 500 のレスポンス。
    */
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<ProblemDetail> handleException(Exception e, HttpServletRequest req) {
+  public ResponseEntity<ProblemDetail> handleException(Exception e) {
     ErrorMessageBuilder errorBuilder =
         new ErrorMessageBuilder(e, CommonExceptionIdConstants.E_SYSTEM, null, null);
     apLog.error(errorBuilder.createLogMessageStackTrace());


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

dressca 、adb2cサンプル、external id サンプルの集約例外ハンドラーのメソッドに使用していない引数が合ったため削除しました。
元の実装で利用していたもので、Problem Detailsの導入で不要になったものが残っていたのだと思われます。
元の実装は[こちら](https://github.com/AlesInfiny/maia/blob/672472366bc8674f319c756ef2282b860ce029a0/samples/web-csr/dressca-backend/system-common/src/main/java/com/dressca/systemcommon/exception/controlleradvice/ExceptionHandlerControllerAdvice.java)を参照してください。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #4865 

<!-- I want to review in Japanese. -->