### PR TITLE
VS Code の JS/TS 拡張機能が正しく動作するように設定ファイルを修正・TypeScript の設定キーの変更に追従

### DIFF
--- a/samples/azure-ad-b2c-sample/auth-frontend/auth-frontend.code-workspace
+++ b/samples/azure-ad-b2c-sample/auth-frontend/auth-frontend.code-workspace
@@ -12,6 +12,6 @@
   "settings": {
     "js/ts.tsdk.path": "azure-ad-b2c-auth-root/node_modules/typescript/lib",
     "js/ts.tsdk.promptToUseWorkspaceVersion": true,
-    "js/ts.validate.enable": false,
+    "js/ts.validate.enabled": false,
   },
 }

--- a/samples/azure-ad-b2c-sample/auth-frontend/auth-frontend.code-workspace
+++ b/samples/azure-ad-b2c-sample/auth-frontend/auth-frontend.code-workspace
@@ -12,6 +12,5 @@
   "settings": {
     "js/ts.tsdk.path": "azure-ad-b2c-auth-root/node_modules/typescript/lib",
     "js/ts.tsdk.promptToUseWorkspaceVersion": true,
-    "js/ts.validate.enabled": false,
   },
 }

--- a/samples/azure-ad-b2c-sample/auth-frontend/auth-frontend.code-workspace
+++ b/samples/azure-ad-b2c-sample/auth-frontend/auth-frontend.code-workspace
@@ -10,8 +10,8 @@
     },
   ],
   "settings": {
-    "typescript.tsdk": "azure-ad-b2c-auth-root/node_modules/typescript/lib",
-    "typescript.enablePromptUseWorkspaceTsdk": true,
-    "typescript.validate.enable": false,
+    "js/ts.tsdk.path": "azure-ad-b2c-auth-root/node_modules/typescript/lib",
+    "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+    "js/ts.validate.enable": false,
   },
 }

--- a/samples/external-id-sample-for-spa/auth-frontend/auth-frontend.code-workspace
+++ b/samples/external-id-sample-for-spa/auth-frontend/auth-frontend.code-workspace
@@ -12,6 +12,6 @@
   "settings": {
     "js/ts.tsdk.path": "external-id-sample-root/node_modules/typescript/lib",
     "js/ts.tsdk.promptToUseWorkspaceVersion": true,
-    "js/ts.validate.enable": false,
+    "js/ts.validate.enabled": false,
   },
 }

--- a/samples/external-id-sample-for-spa/auth-frontend/auth-frontend.code-workspace
+++ b/samples/external-id-sample-for-spa/auth-frontend/auth-frontend.code-workspace
@@ -10,8 +10,8 @@
     },
   ],
   "settings": {
-    "typescript.tsdk": "external-id-sample-root/node_modules/typescript/lib",
-    "typescript.enablePromptUseWorkspaceTsdk": true,
-    "typescript.validate.enable": false,
+    "js/ts.tsdk.path": "external-id-sample-root/node_modules/typescript/lib",
+    "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+    "js/ts.validate.enable": false,
   },
 }

--- a/samples/external-id-sample-for-spa/auth-frontend/auth-frontend.code-workspace
+++ b/samples/external-id-sample-for-spa/auth-frontend/auth-frontend.code-workspace
@@ -12,6 +12,5 @@
   "settings": {
     "js/ts.tsdk.path": "external-id-sample-root/node_modules/typescript/lib",
     "js/ts.tsdk.promptToUseWorkspaceVersion": true,
-    "js/ts.validate.enabled": false,
   },
 }

--- a/samples/web-csr/dressca-frontend/dressca-frontend.code-workspace
+++ b/samples/web-csr/dressca-frontend/dressca-frontend.code-workspace
@@ -16,6 +16,6 @@
   "settings": {
     "js/ts.tsdk.path": "dressca-root/node_modules/typescript/lib",
     "js/ts.tsdk.promptToUseWorkspaceVersion": true,
-    "js/ts.validate.enable": false,
+    "js/ts.validate.enabled": false,
   },
 }

--- a/samples/web-csr/dressca-frontend/dressca-frontend.code-workspace
+++ b/samples/web-csr/dressca-frontend/dressca-frontend.code-workspace
@@ -16,6 +16,5 @@
   "settings": {
     "js/ts.tsdk.path": "dressca-root/node_modules/typescript/lib",
     "js/ts.tsdk.promptToUseWorkspaceVersion": true,
-    "js/ts.validate.enabled": false,
   },
 }

--- a/samples/web-csr/dressca-frontend/dressca-frontend.code-workspace
+++ b/samples/web-csr/dressca-frontend/dressca-frontend.code-workspace
@@ -14,8 +14,8 @@
     },
   ],
   "settings": {
-    "typescript.tsdk": "dressca-root/node_modules/typescript/lib",
-    "typescript.enablePromptUseWorkspaceTsdk": true,
-    "typescript.validate.enable": false,
+    "js/ts.tsdk.path": "dressca-root/node_modules/typescript/lib",
+    "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+    "js/ts.validate.enable": false,
   },
 }


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと
- 本来、下記の対応時に `typescript.validate.enable": false` を削除すべきだったが、削除していないために VSCode 組み込みの JS/TS 拡張機能で JS/TS の構文エラーが「問題」タブに出てこなくなってしまっていた。
- https://github.com/AlesInfiny/maris/issues/889

### 経緯
- Volar(および旧 VS Code 拡張機能)ではVue独自のTS/JSの言語サーバーを上げて、組み込みのTS/JS拡張機能を無効にしていた（テイクオーバーモード）
- しかし、 Vue(Official)へアップデートの際に組み込みの拡張機能とうまく統合された（ハイブリッドモード）ので、無効にする必要がなくなった
- 無効にすると、 JS/TS の構文エラーが「問題」タブに出てこなくなってしまう

- VS Code の下記の変更により、TypeScript の設定キーが非推奨になっていたため、追従しました。
>https://code.visualstudio.com/updates/v1_110#_unified-javascript-and-typescript-settings

## この Pull request では実施していないこと

- ドキュメントの下記の箇所は、ソースコードへのリンクになっているため、修正不要です。
https://maia.alesinfiny.org/guidebooks/how-to-develop/csr/vue-js/setting-workspaces/#settings-vscode-workspace



## Issues や Discussions 、関連する Web サイトなどへのリンク

- Vue（Official）への移行当時、構文エラーが「問題」タブに出てくることを確認した記憶があるので、タブに出てこなくなった理由は異なる可能性があるが、これ以上経緯を追うことは困難なので、現状に応じて「問題」タブに出る状態が正になるよう設定します。

<!-- I want to review in Japanese. -->