### PR TITLE
Dressca-CMSで表示される取得件数と実際に取得される件数が異なる不具合に対応

### DIFF
--- a/samples/dressca-cms/announcement/src/main/java/com/dressca/cms/announcement/infrastructure/repository/mybatis/mapper/AnnouncementCustomMapper.xml
+++ b/samples/dressca-cms/announcement/src/main/java/com/dressca/cms/announcement/infrastructure/repository/mybatis/mapper/AnnouncementCustomMapper.xml
@@ -22,7 +22,7 @@
   </resultMap>
   
   <select id="findAnnouncementsWithContentsByOffsetAndLimit" resultMap="AnnouncementWithContentsResultMap">
-    SELECT 
+    SELECT
       a.id,
       a.category,
       a.post_date_time,
@@ -36,11 +36,15 @@
       ac.title,
       ac.message,
       ac.link_url
-    FROM announcements a
+    FROM (
+      SELECT *
+      FROM announcements
+      WHERE is_deleted = false
+      ORDER BY post_date_time DESC, id
+      LIMIT #{limit} OFFSET #{offset}
+    ) a
     LEFT JOIN announcement_contents ac ON a.id = ac.announcement_id
-    WHERE a.is_deleted = false
     ORDER BY a.post_date_time DESC, a.id
-    LIMIT #{limit} OFFSET #{offset}
   </select>
 
   <select id="findByIdWithContents" resultMap="AnnouncementWithContentsResultMap">

--- a/samples/dressca-cms/announcement/src/main/java/com/dressca/cms/announcement/infrastructure/repository/mybatis/mapper/AnnouncementCustomMapper.xml
+++ b/samples/dressca-cms/announcement/src/main/java/com/dressca/cms/announcement/infrastructure/repository/mybatis/mapper/AnnouncementCustomMapper.xml
@@ -37,7 +37,15 @@
       ac.message,
       ac.link_url
     FROM (
-      SELECT *
+      SELECT 
+        id,
+        category,
+        post_date_time,
+        expire_date_time,
+        display_priority,
+        created_at,
+        changed_at,
+        is_deleted
       FROM announcements
       WHERE is_deleted = false
       ORDER BY post_date_time DESC, id


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

- findAnnouncementsWithContentsByOffsetAndLimit のクエリを修正し、正しい件数分取得できるように修正しました。

不具合の詳細は、以下を参照ください。

- #5110 

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #5110 

<!-- I want to review in Japanese. -->