### PR TITLE
Azure AD B2C サンプルにおける Spring Cloud Azure のサポートバージョンについて明記

### DIFF
--- a/documents/contents/samples/dressca/azure-ad-b2c/index.md
+++ b/documents/contents/samples/dressca/azure-ad-b2c/index.md
@@ -49,8 +49,14 @@ Azure Active Directory B2C （以降、 Azure AD B2C ）を利用したユーザ
 - フロントエンド
     - [MSAL.js :material-open-in-new:](https://www.npmjs.com/package/@azure/msal-browser){ target=_blank }
 - バックエンド
-    - [spring-cloud-azure-starter-active-directory-b2c :material-open-in-new:](https://central.sonatype.com/artifact/com.azure.spring/spring-cloud-azure-starter-active-directory-b2c){ target=_blank }
-    - [spring-cloud-azure-dependencies :material-open-in-new:](https://central.sonatype.com/artifact/com.azure.spring/spring-cloud-azure-dependencies){ target=_blank }
+    - [spring-cloud-azure-starter-active-directory-b2c :material-open-in-new:](https://central.sonatype.com/artifact/com.azure.spring/spring-cloud-azure-starter-active-directory-b2c/7.2.0){ target=_blank }
+    - [spring-cloud-azure-dependencies :material-open-in-new:](https://central.sonatype.com/artifact/com.azure.spring/spring-cloud-azure-dependencies/7.2.0){ target=_blank }
+
+!!! warning
+
+    本サンプルでサポートしている Spring Cloud Azure (`com.azure.spring:spring-cloud-azure-starter-active-directory-b2c` および `com.azure.spring:spring-cloud-azure-dependencies`) のバージョンは 7.2.0 です。
+    Spring Cloud Azure 7.3.0 以降では [`tid` claim の検証が追加されました :material-open-in-new:](https://github.com/Azure/azure-sdk-for-java/releases/tag/spring-cloud-azure_7.3.0){ target=_blank } が、本サンプルで採用している User Flow で発行されるアクセストークンには `tid` claim が含まれません。
+    7.3.0 以降へ更新する場合は、 [Custom Policy :material-open-in-new:](https://learn.microsoft.com/ja-jp/azure/active-directory-b2c/custom-policy-get-started){ target=_blank } への切り替えなど、別途対応が必要です。
 
 ## 本サンプルを利用する際の検討事項 {#consideration}
 

--- a/documents/contents/samples/dressca/azure-ad-b2c/index.md
+++ b/documents/contents/samples/dressca/azure-ad-b2c/index.md
@@ -52,7 +52,7 @@ Azure Active Directory B2C （以降、 Azure AD B2C ）を利用したユーザ
     - [spring-cloud-azure-starter-active-directory-b2c :material-open-in-new:](https://central.sonatype.com/artifact/com.azure.spring/spring-cloud-azure-starter-active-directory-b2c/7.2.0){ target=_blank }
     - [spring-cloud-azure-dependencies :material-open-in-new:](https://central.sonatype.com/artifact/com.azure.spring/spring-cloud-azure-dependencies/7.2.0){ target=_blank }
 
-!!! warning
+!!! warning "Spring Cloud Azure のサポートバージョンについて"
 
     本サンプルでサポートしている Spring Cloud Azure (`com.azure.spring:spring-cloud-azure-starter-active-directory-b2c` および `com.azure.spring:spring-cloud-azure-dependencies`) のバージョンは 7.2.0 です。
     Spring Cloud Azure 7.3.0 以降では [`tid` claim の検証が追加されました :material-open-in-new:](https://github.com/Azure/azure-sdk-for-java/releases/tag/spring-cloud-azure_7.3.0){ target=_blank } が、本サンプルで採用している User Flow で発行されるアクセストークンには `tid` claim が含まれません。

--- a/samples/azure-ad-b2c-sample/README.md
+++ b/samples/azure-ad-b2c-sample/README.md
@@ -165,9 +165,9 @@ auth-frontend
 - フロントエンドアプリケーション
     - [MSAL.js](https://www.npmjs.com/package/@azure/msal-browser)
 
-> [!NOTE]
-> 本サンプルでサポートしている `com.azure.spring:spring-cloud-azure-starter-active-directory-b2c` および `com.azure.spring:spring-cloud-azure-dependencies` のバージョンは 7.2.0 です。
-> `com.azure.spring:spring-cloud-azure-starter-active-directory-b2c` および `com.azure.spring:spring-cloud-azure-dependencies` の 7.3.0 以降では [`tid` claim の検証が追加されました](https://github.com/Azure/azure-sdk-for-java/releases/tag/spring-cloud-azure_7.3.0) が、本サンプルで採用している User Flow のアクセストークンには `tid` claim が含まれません。
+> [!WARNING]
+> 本サンプルでサポートしている Spring Cloud Azure (`com.azure.spring:spring-cloud-azure-starter-active-directory-b2c` および `com.azure.spring:spring-cloud-azure-dependencies`) のバージョンは 7.2.0 です。
+> Spring Cloud Azure 7.3.0 以降では [`tid` claim の検証が必須化されました](https://github.com/Azure/azure-sdk-for-java/releases/tag/spring-cloud-azure_7.3.0) が、本サンプルで採用している User Flow で発行されるアクセストークンは `tid` claim が含まれません。
 > 7.3.0 以降へ更新する場合は、 [Custom Policy](https://learn.microsoft.com/ja-jp/azure/active-directory-b2c/custom-policy-get-started) への切り替えなど、別途対応が必要です。
 
 その他の使用 OSS は、 AlesInfiny Maia のサンプルアプリケーションに準じます。

--- a/samples/azure-ad-b2c-sample/README.md
+++ b/samples/azure-ad-b2c-sample/README.md
@@ -167,7 +167,7 @@ auth-frontend
 
 > [!WARNING]
 > 本サンプルでサポートしている Spring Cloud Azure (`com.azure.spring:spring-cloud-azure-starter-active-directory-b2c` および `com.azure.spring:spring-cloud-azure-dependencies`) のバージョンは 7.2.0 です。
-> Spring Cloud Azure 7.3.0 以降では [`tid` claim の検証が必須化されました](https://github.com/Azure/azure-sdk-for-java/releases/tag/spring-cloud-azure_7.3.0) が、本サンプルで採用している User Flow で発行されるアクセストークンは `tid` claim が含まれません。
+> Spring Cloud Azure 7.3.0 以降では [`tid` claim の検証が追加されました](https://github.com/Azure/azure-sdk-for-java/releases/tag/spring-cloud-azure_7.3.0) が、本サンプルで採用している User Flow で発行されるアクセストークンは `tid` claim が含まれません。
 > 7.3.0 以降へ更新する場合は、 [Custom Policy](https://learn.microsoft.com/ja-jp/azure/active-directory-b2c/custom-policy-get-started) への切り替えなど、別途対応が必要です。
 
 その他の使用 OSS は、 AlesInfiny Maia のサンプルアプリケーションに準じます。
@@ -313,7 +313,7 @@ BUILD SUCCESSFUL in 2s
 
     ```gradle
     ext {
-      springCloudAzureVersion = "[使用するライブラリのバージョン番号を記述。サンプルでは 7.x.x]"
+      springCloudAzureVersion = "[使用するライブラリのバージョン番号を記述。サンプルでは 7.2.0]"
 
       supportDependencies = [
         spring_cloud_azure_starter_ad_b2c : "com.azure.spring:spring-cloud-azure-starter-active-directory-b2c",

--- a/samples/azure-ad-b2c-sample/README.md
+++ b/samples/azure-ad-b2c-sample/README.md
@@ -42,8 +42,8 @@ Azure サブスクリプションを持っていない場合、 [無料アカウ
 本サンプルは以下の環境で動作確認を行っています。
 
 - Java 21
-- Node.js v24.14.1
-- Visual Studio Code 1.115.0
+- Node.js v24.18.0
+- Visual Studio Code 1.127.0
 
 ## サンプルの構成
 
@@ -160,10 +160,15 @@ auth-frontend
 本サンプルでは、バックエンド、フロントエンドアプリケーションそれぞれで OSS を使用しています。
 
 - バックエンドアプリケーション
-    - [spring-cloud-azure-starter-active-directory-b2c](https://central.sonatype.com/artifact/com.azure.spring/spring-cloud-azure-starter-active-directory-b2c)
-    - [spring-cloud-azure-dependencies](https://central.sonatype.com/artifact/com.azure.spring/spring-cloud-azure-dependencies)
+    - [spring-cloud-azure-starter-active-directory-b2c](https://central.sonatype.com/artifact/com.azure.spring/spring-cloud-azure-starter-active-directory-b2c/7.2.0)
+    - [spring-cloud-azure-dependencies](https://central.sonatype.com/artifact/com.azure.spring/spring-cloud-azure-dependencies/7.2.0)
 - フロントエンドアプリケーション
     - [MSAL.js](https://www.npmjs.com/package/@azure/msal-browser)
+
+> [!NOTE]
+> 本サンプルでサポートしている `com.azure.spring:spring-cloud-azure-starter-active-directory-b2c` および `com.azure.spring:spring-cloud-azure-dependencies` のバージョンは 7.2.0 です。
+> `com.azure.spring:spring-cloud-azure-starter-active-directory-b2c` および `com.azure.spring:spring-cloud-azure-dependencies` の 7.3.0 以降では [`tid` claim の検証が追加されました](https://github.com/Azure/azure-sdk-for-java/releases/tag/spring-cloud-azure_7.3.0) が、本サンプルで採用している User Flow のアクセストークンには `tid` claim が含まれません。
+> 7.3.0 以降へ更新する場合は、 [Custom Policy](https://learn.microsoft.com/ja-jp/azure/active-directory-b2c/custom-policy-get-started) への切り替えなど、別途対応が必要です。
 
 その他の使用 OSS は、 AlesInfiny Maia のサンプルアプリケーションに準じます。
 

--- a/samples/azure-ad-b2c-sample/README.md
+++ b/samples/azure-ad-b2c-sample/README.md
@@ -167,7 +167,7 @@ auth-frontend
 
 > [!WARNING]
 > 本サンプルでサポートしている Spring Cloud Azure (`com.azure.spring:spring-cloud-azure-starter-active-directory-b2c` および `com.azure.spring:spring-cloud-azure-dependencies`) のバージョンは 7.2.0 です。
-> Spring Cloud Azure 7.3.0 以降では [`tid` claim の検証が追加されました](https://github.com/Azure/azure-sdk-for-java/releases/tag/spring-cloud-azure_7.3.0) が、本サンプルで採用している User Flow で発行されるアクセストークンは `tid` claim が含まれません。
+> Spring Cloud Azure 7.3.0 以降では [`tid` claim の検証が追加されました](https://github.com/Azure/azure-sdk-for-java/releases/tag/spring-cloud-azure_7.3.0) が、本サンプルで採用している User Flow で発行されるアクセストークンには `tid` claim が含まれません。
 > 7.3.0 以降へ更新する場合は、 [Custom Policy](https://learn.microsoft.com/ja-jp/azure/active-directory-b2c/custom-policy-get-started) への切り替えなど、別途対応が必要です。
 
 その他の使用 OSS は、 AlesInfiny Maia のサンプルアプリケーションに準じます。


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

Azure AD B2C サンプルでサポートする `com.azure.spring:spring-cloud-azure-starter-active-directory-b2c` および `com.azure.spring:spring-cloud-azure-dependencies` のバージョンが 7.2.0 である旨を README とドキュメントに追記しました。

あわせて、7.3.0 以降では `tid` claim の検証が追加される一方、本サンプルで採用している User Flow で発行されるアクセストークンには `tid` claim が含まれないため、7.3.0 以降へ更新する場合は Custom Policy への切り替えなど別途対応が必要である旨を記載しました。

<img width="738" height="176" alt="image" src="https://github.com/user-attachments/assets/4c32723c-5f40-408a-a1dc-185fb6f67736" />

ドキュメントに記載の VSCode/Node のバージョン情報は最新のものに更新しました。

## この Pull request では実施していないこと

Azure AD B2C サンプルで利用する認証方式の変更は実施していません。

具体的には、User Flow から Custom Policy への切り替えや、Spring Security による検証方式への切り替えは実施していません。

## Issues や Discussions 、関連する Web サイトなどへのリンク

- https://github.com/AlesInfiny/maia/issues/4986
- Spring Cloud Azure 7.3.0 Release Notes
  - https://github.com/Azure/azure-sdk-for-java/releases/tag/spring-cloud-azure_7.3.0
- Azure AD B2C でカスタム ポリシーの使用を開始する
  - https://learn.microsoft.com/ja-jp/azure/active-directory-b2c/custom-policy-get-started

<!-- I want to review in Japanese. -->