### PR TITLE
MkDocs の GitHub コード取得時の 429 エラーに対応

### DIFF
--- a/documents/hooks/github_markdown_fetcher.py
+++ b/documents/hooks/github_markdown_fetcher.py
@@ -1,10 +1,36 @@
 import re
+import time
+import urllib.error
 import urllib.request
+
+MAX_RETRIES = 3
+TIMEOUT_SECONDS = 10
+
+
+def fetch_url(url):
+    for attempt in range(MAX_RETRIES + 1):
+        try:
+            with urllib.request.urlopen(url, timeout=TIMEOUT_SECONDS) as response:
+                return response.read().decode('utf-8')
+        except urllib.error.HTTPError as error:
+            if error.code != 429 or attempt == MAX_RETRIES:
+                raise RuntimeError(f"Failed to fetch GitHub markdown: {url}") from error
+
+            retry_after = error.headers.get('Retry-After')
+            try:
+                wait_seconds = int(retry_after) if retry_after else 2 ** attempt
+            except ValueError:
+                wait_seconds = 2 ** attempt
+
+            time.sleep(wait_seconds)
+        except urllib.error.URLError as error:
+            raise RuntimeError(f"Failed to fetch GitHub markdown: {url}") from error
+
 
 def replacer(match):
     filename = f"{match.group('filename')}.{match.group('extension')}"
     url = f"https://raw.githubusercontent.com/{match.group('user')}/{filename}"
-    code = urllib.request.urlopen(url).read().decode('utf-8')
+    code = fetch_url(url)
     spacing = match.group('spacing')
     
     # begin と end が整数に変換できるかどうかをチェック


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

MkDocs のビルド時に GitHub 上の Markdown / コード参照を取得する処理で、GitHub から HTTP 429 が返された場合にリトライするようにしました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->